### PR TITLE
Request to rename/avoid MicroState

### DIFF
--- a/gufe/__init__.py
+++ b/gufe/__init__.py
@@ -4,4 +4,4 @@ __version__ = _version.get_versions()['version']
 
 from .ligandcomponent import LigandComponent
 from .proteincomponent import ProteinComponent
-from .microstate import Microstate
+from .chemicalstate import ChemicalState

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -1,6 +1,6 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
-class Microstate:
+class ChemicalState:
     pass
     # TODO: DD Magic


### PR DESCRIPTION
Microstates is a stat mech loaded term - asking as someone that still has to deal with profs regularly, can we just avoid it 🙃 

Here I propose ChemicalState. The idea being that ChemicalState(s) are real states that are joined by various AlchemicalStates along a free energy network.

That being said, if the intent is to truly represent a very specific microstate of a system (which didn't seem the case from this week's F@H alchemy call), then that's a different issue...