### PR TITLE
Added initial attributes and methods for ChemicalState

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,3 @@ dependencies:
   - openff-toolkit
   - openeye-toolkits
   - typing-extensions
-  - frozendict

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - openff-toolkit
   - openeye-toolkits
   - typing-extensions
+  - frozendict

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -1,7 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
-from typing import Dict
+from typing import Dict, Optional
 
 import numpy as np
 from frozendict import frozendict
@@ -31,8 +31,8 @@ class ChemicalState:
     def __init__(
             self,
             components: Dict[str, RDKitMol],
-            box_vectors: np.ndarray,
-            identifier: str = None,
+            box_vectors: Optional[np.ndarray] = None,
+            identifier: Optional[str] = None,
             ):
         """Create a node for an alchemical network.
 
@@ -52,25 +52,36 @@ class ChemicalState:
             `AlchemicalNetwork`
 
         """
-        self.components = frozendict(components)
-        self.box_vectors = box_vectors
-        self.identifier = identifier
+        self._components = frozendict(components)
+        self._box_vectors = box_vectors
+        self._identifier = identifier
 
     def __hash__(self):
-        return hash((self.components, self.identifier))
+        return hash((self._components, self._identifier, self._box_vectors))
+
+    @property
+    def components(self):
+        return self._components
+
+    @property
+    def box_vectors(self):
+        return np.array(self._box_vectors)
+
+    @property
+    def identifier(self):
+        return self._identifier
+
+    @classmethod
+    def as_protein_ligand_solvent(cls):
+        """
+
+        """
+        ...
 
 
-class ProteinLigandSolventMicrostate(ChemicalState):
-    """
-
-    """
-    ...
-
-
-class LigandSolvent(ChemicalState):
-    """
-
-    """
-    ...
-
-    pass
+    @classmethod
+    def as_ligand_solvent(cls):
+        """
+    
+        """
+        ...

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -53,8 +53,12 @@ class ChemicalState:
 
         """
         self._components = frozendict(components)
-        self._box_vectors = box_vectors
         self._identifier = identifier
+
+        if box_vectors is None:
+            self._box_vectors = np.array([np.nan]*9)
+        else:
+            self._box_vectors = box_vectors
 
     def __hash__(self):
         return hash((self._components, self._identifier, self._box_vectors))

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -4,11 +4,12 @@
 from typing import Dict, Optional
 
 import numpy as np
+from openff.toolkit.utils.serialization import Serializable
 
 from .component import Component
 
 
-class ChemicalState:
+class ChemicalState(Serializable):
     """A node of an alchemical network.
 
     Attributes
@@ -62,10 +63,29 @@ class ChemicalState:
     def __hash__(self):
         return hash(
             (
-                tuple(self._components.items()),
+                tuple(sorted(self._components.items())),
                 self._box_vectors,
                 self._identifier,
             )
+        )
+
+    def to_dict(self):
+        return {
+            "components": {
+                key: value.to_dict() for key, value in self.components.items()
+            },
+            "box_vectors": self.box_vectors.tolist(),
+            "identifier": self.identifier,
+        }
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(
+            components={
+                key: Component.from_dict(value) for key, value in d["components"]
+            },
+            box_vectors=np.array(d["box_vectors"]),
+            identifier=d["identifier"],
         )
 
     @property

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -16,12 +16,12 @@ class ChemicalState:
     Attributes
     ----------
     components
-        The molecular representation of the chemical state, including connectivity and
-        coordinates. This is a frozendict with user-defined labels as keys, RDKit
-        molecules as values.
+        The molecular representation of the chemical state, including
+        connectivity and coordinates. This is a frozendict with user-defined
+        labels as keys, RDKit molecules as values.
     box_vectors
-        Numpy array indicating shape and size of unit cell for the system.
-        May be a partial definition to allow for variability on certain dimensions.
+        Numpy array indicating shape and size of unit cell for the system. May
+        be a partial definition to allow for variability on certain dimensions.
     identifier
         Optional identifier for the chemical state; used as part of the
         (hashable) graph node itself when the chemical state is added to an
@@ -40,12 +40,13 @@ class ChemicalState:
         Attributes
         ----------
         components
-            The molecular representation of the chemical state, including connectivity and
-            coordinates. Given as a dict with user-defined labels as keys, RDKit
-            molecules as values.
+            The molecular representation of the chemical state, including
+            connectivity and coordinates. Given as a dict with user-defined
+            labels as keys, RDKit molecules as values.
         box_vectors
             Numpy array indicating shape and size of unit cell for the system.
-            May be a partial definition to allow for variability on certain dimensions.
+            May be a partial definition to allow for variability on certain
+            dimensions.
         identifier
             Optional identifier for the chemical state; used as part of the
             (hashable) graph node itself when the chemical state is added to an
@@ -55,7 +56,6 @@ class ChemicalState:
         self.components = frozendict(components)
         self.box_vectors = box_vectors
         self.identifier = identifier
-
 
     def __hash__(self):
         return hash((self.components, self.identifier))

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -5,10 +5,9 @@ from typing import Dict
 
 import numpy as np
 from frozendict import frozendict
-from openff.toolkit.topology import Molecule, Topology
-from openff.interchange.components.interchange import Interchange
 
 from .custom_typing import RDKitMol
+
 
 class ChemicalState:
     """A node of an alchemical network.

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -1,6 +1,76 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
+from typing import Dict
+
+import numpy as np
+from frozendict import frozendict
+from openff.toolkit.topology import Molecule, Topology
+from openff.interchange.components.interchange import Interchange
+
+from .custom_typing import RDKitMol
+
 class ChemicalState:
+    """A node of an alchemical network.
+
+    Attributes
+    ----------
+    components
+        The molecular representation of the chemical state, including connectivity and
+        coordinates. Given as a dict with user-defined labels as keys, RDKit
+        molecules as values.
+    box_vectors
+        Numpy array indicating shape and size of unit cell for the system.
+        May be a partial definition to allow for variability on certain dimensions.
+    identifier
+        Optional identifier for the chemical state; used as part of the
+        (hashable) graph node itself when the chemical state is added to an
+        `AlchemicalNetwork`
+
+    """
+
+    def __init__(
+            self,
+            components: Dict[str, RDKitMol],
+            box_vectors: np.ndarray,
+            identifier: str = None,
+            ):
+        """Create a node for an alchemical network.
+
+        Attributes
+        ----------
+        components
+            The molecular representation of the chemical state, including connectivity and
+            coordinates. This is a `frozendict`
+        box_vectors
+            Numpy array indicating shape and size of unit cell for the system.
+            May be a partial definition to allow for variability on certain dimensions.
+        identifier
+            Optional identifier for the chemical state; used as part of the
+            (hashable) graph node itself when the chemical state is added to an
+            `AlchemicalNetwork`
+
+        """
+        self.components = frozendict(components)
+        self.box_vectors = box_vectors
+        self.identifier = identifier
+
+
+    def __hash__(self):
+        return hash((self.components, self.identifier))
+
+
+class ProteinLigandSolventMicrostate(ChemicalState):
+    """
+
+    """
+    ...
+
+
+class LigandSolvent(ChemicalState):
+    """
+
+    """
+    ...
+
     pass
-    # TODO: DD Magic

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -17,7 +17,7 @@ class ChemicalState:
     ----------
     components
         The molecular representation of the chemical state, including connectivity and
-        coordinates. Given as a dict with user-defined labels as keys, RDKit
+        coordinates. This is a frozendict with user-defined labels as keys, RDKit
         molecules as values.
     box_vectors
         Numpy array indicating shape and size of unit cell for the system.
@@ -41,7 +41,8 @@ class ChemicalState:
         ----------
         components
             The molecular representation of the chemical state, including connectivity and
-            coordinates. This is a `frozendict`
+            coordinates. Given as a dict with user-defined labels as keys, RDKit
+            molecules as values.
         box_vectors
             Numpy array indicating shape and size of unit cell for the system.
             May be a partial definition to allow for variability on certain dimensions.

--- a/gufe/chemicalstate.py
+++ b/gufe/chemicalstate.py
@@ -4,9 +4,8 @@
 from typing import Dict, Optional
 
 import numpy as np
-from frozendict import frozendict
 
-from .custom_typing import RDKitMol
+from .component import Component
 
 
 class ChemicalState:
@@ -17,23 +16,23 @@ class ChemicalState:
     components
         The molecular representation of the chemical state, including
         connectivity and coordinates. This is a frozendict with user-defined
-        labels as keys, RDKit molecules as values.
+        labels as keys, `Component`s as values.
     box_vectors
         Numpy array indicating shape and size of unit cell for the system. May
         be a partial definition to allow for variability on certain dimensions.
     identifier
         Optional identifier for the chemical state; used as part of the
         (hashable) graph node itself when the chemical state is added to an
-        `AlchemicalNetwork`
+        `AlchemicalNetwork`.
 
     """
 
     def __init__(
-            self,
-            components: Dict[str, RDKitMol],
-            box_vectors: Optional[np.ndarray] = None,
-            identifier: Optional[str] = None,
-            ):
+        self,
+        components: Dict[str, Component],
+        box_vectors: Optional[np.ndarray] = None,
+        identifier: Optional[str] = None,
+    ):
         """Create a node for an alchemical network.
 
         Attributes
@@ -41,31 +40,37 @@ class ChemicalState:
         components
             The molecular representation of the chemical state, including
             connectivity and coordinates. Given as a dict with user-defined
-            labels as keys, RDKit molecules as values.
+            labels as keys, `Component`s as values.
         box_vectors
-            Numpy array indicating shape and size of unit cell for the system.
-            May be a partial definition to allow for variability on certain
-            dimensions.
+            Optional `numpy` array indicating shape and size of unit cell for
+            the system. May be a partial definition to allow for variability on
+            certain dimensions.
         identifier
-            Optional identifier for the chemical state; used as part of the
-            (hashable) graph node itself when the chemical state is added to an
-            `AlchemicalNetwork`
+            Optional identifier for the chemical state; included with the other
+            attributes as part of the (hashable) graph node itself when the
+            chemical state is added to an `AlchemicalNetwork`.
 
         """
-        self._components = frozendict(components)
+        self._components = components
         self._identifier = identifier
 
         if box_vectors is None:
-            self._box_vectors = np.array([np.nan]*9)
+            self._box_vectors = np.array([np.nan] * 9)
         else:
             self._box_vectors = box_vectors
 
     def __hash__(self):
-        return hash((self._components, self._identifier, self._box_vectors))
+        return hash(
+            (
+                tuple(self._components.items()),
+                self._box_vectors,
+                self._identifier,
+            )
+        )
 
     @property
     def components(self):
-        return self._components
+        return dict(self._components)
 
     @property
     def box_vectors(self):
@@ -75,17 +80,19 @@ class ChemicalState:
     def identifier(self):
         return self._identifier
 
-    @classmethod
-    def as_protein_ligand_solvent(cls):
-        """
+    @property
+    def charge(self):
+        """Total charge for the ChemicalState."""
+        return sum([component.charge for component in self._components.values()])
 
-        """
+    @classmethod
+    def as_protein_smallmolecule_solvent(cls):
+        """ """
+        # alternate initializer for typical protein+ligand+solvent system
         ...
 
-
     @classmethod
-    def as_ligand_solvent(cls):
-        """
-    
-        """
+    def as_smallmolecule_solvent(cls):
+        """ """
+        # alternate initializer for typical ligand+solvent system
         ...


### PR DESCRIPTION
Included `__init__` for core set of attributes for `ChemicalState` from working session with @richardjgowers. Assumes that `ChemicalState` components are all RDKit molecules, and that that the `ChemicalState` is immutable upon instantiation.