### PR TITLE
Make `ChemicalSystem` an `abc.Mapping`

### DIFF
--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -1,6 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
+from collections import abc
 from typing import Dict, Optional
 
 import numpy as np
@@ -9,7 +10,7 @@ from openff.toolkit.utils.serialization import Serializable
 from .component import Component
 
 
-class ChemicalSystem(Serializable):
+class ChemicalSystem(Serializable, abc.Mapping):
     """A node of an alchemical network.
 
     Attributes
@@ -129,6 +130,12 @@ class ChemicalSystem(Serializable):
 
     def __getitem__(self, item):
         return self.components[item]
+
+    def __iter__(self):
+        return iter(self.components)
+
+    def __len__(self):
+        return len(self.components)
 
     @classmethod
     def as_protein_smallmolecule_solvent(cls):

--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -127,6 +127,9 @@ class ChemicalSystem(Serializable):
                 total_charge += fc
         return total_charge
 
+    def __getitem__(self, item):
+        return self.components[item]
+
     @classmethod
     def as_protein_smallmolecule_solvent(cls):
         """ """

--- a/gufe/tests/test_chemicalsystem.py
+++ b/gufe/tests/test_chemicalsystem.py
@@ -54,6 +54,9 @@ def test_ligand_construction(solv_comp, toluene_ligand_comp):
     )
 
     assert len(state.components) == 2
+    assert len(state) == 2
+
+    assert list(state) == ['solvent', 'ligand']
 
     assert state.components['solvent'] == solv_comp
     assert state.components['ligand'] == toluene_ligand_comp
@@ -71,6 +74,9 @@ def test_complex_construction(prot_comp, solv_comp, toluene_ligand_comp):
     )
 
     assert len(state.components) == 3
+    assert len(state) == 3
+
+    assert list(state) == ['protein', 'solvent', 'ligand']
 
     assert state.components['protein'] == prot_comp
     assert state.components['solvent'] == solv_comp

--- a/gufe/tests/test_chemicalsystem.py
+++ b/gufe/tests/test_chemicalsystem.py
@@ -57,6 +57,8 @@ def test_ligand_construction(solv_comp, toluene_ligand_comp):
 
     assert state.components['solvent'] == solv_comp
     assert state.components['ligand'] == toluene_ligand_comp
+    assert state['solvent'] == solv_comp
+    assert state['ligand'] == toluene_ligand_comp
 
 
 def test_complex_construction(prot_comp, solv_comp, toluene_ligand_comp):
@@ -73,6 +75,9 @@ def test_complex_construction(prot_comp, solv_comp, toluene_ligand_comp):
     assert state.components['protein'] == prot_comp
     assert state.components['solvent'] == solv_comp
     assert state.components['ligand'] == toluene_ligand_comp
+    assert state['protein'] == prot_comp
+    assert state['solvent'] == solv_comp
+    assert state['ligand'] == toluene_ligand_comp
 
 
 def test_hash_and_eq(prot_comp, solv_comp, toluene_ligand_comp):


### PR DESCRIPTION
In starting to write code that might use this, I'm finding that `chemical_system.components['thing']` is coming up over and over again. I propose making `ChemicalSystem` an `abc.Mapping`, so that we can use it as `chemical_system['thing']`.