### PR TITLE
Tightening up `SolventComponent`

### DIFF
--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -112,14 +112,13 @@ class SolventComponent(Component):
         """Solvents don't have a formal charge defined so this returns None"""
         return None
 
-    def __eq__(self, other: SolventComponent):
-        try:
-            return (self.smiles == other.smiles and
-                    self.positive_ion == other.positive_ion and
-                    self.negative_ion == other.negative_ion and
-                    self.ion_concentration == other.ion_concentration)
-        except AttributeError:
-            return False
+    def __eq__(self, other):
+        if not isinstance(other, SolventComponent):
+            return NotImplemented
+        return (self.smiles == other.smiles and
+                self.positive_ion == other.positive_ion and
+                self.negative_ion == other.negative_ion and
+                self.ion_concentration == other.ion_concentration)
 
     def __hash__(self):
         return hash((self.smiles, self.positive_ion, self.negative_ion,

--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -61,13 +61,13 @@ class SolventComponent(Component):
             norm = positive_ion.strip('-+').capitalize()
             if norm not in _CATIONS:
                 raise ValueError(f"Invalid positive ion, got {positive_ion}")
-            positive_ion = norm
+            positive_ion = norm + '+'
         self._positive_ion = positive_ion
         if negative_ion is not None:
             norm = negative_ion.strip('-+').capitalize()
             if norm not in _ANIONS:
                 raise ValueError(f"Invalid negative ion, got {negative_ion}")
-            negative_ion = norm
+            negative_ion = norm + '-'
         self._negative_ion = negative_ion
 
         self._neutralize = neutralize

--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -1,50 +1,82 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
-from typing import Tuple
-import math
 from openff.units import unit
+from typing import Optional
 
 from gufe import Component
+
+_CATIONS = {'Cs', 'K', 'Li', 'Na', 'Rb'}
+_ANIONS = {'Cl', 'Br', 'F', 'I'}
 
 
 # really wanted to make this a dataclass but then can't sort & strip ion input
 class SolventComponent(Component):
-
     """Solvent molecules in a chemical state
 
     This component represents the abstract idea of the solvent and ions present
     around the other components, rather than a list of specific water molecules
     and their coordinates.  This abstract representation is later made concrete
-    by specific methods.
+    by specific MD engine methods.
     """
-    def __init__(self, smiles: str = 'O',
-                 ions: Tuple[str, ...] = None,
+    _smiles: str
+    _ions: Optional[tuple[str, str]]
+    _neutralize: bool
+    _ion_concentration: unit.Quantity
+
+    def __init__(self, *,  # force kwarg usage
+                 smiles: str = 'O',
+                 ions: tuple[str, str] = None,
                  neutralize: bool = True,
-                 concentration: unit.Quantity = None):
+                 ion_concentration: unit.Quantity = None):
         """
         Parameters
         ----------
         smiles : str, optional
           smiles of the solvent, default 'O' (water)
-        ions : list of str, optional
-          ions in the system, default `None`
+        ions : tuple of str, optional
+          the pair of ions which is used to neutralize (if neutralize=True) and
+          bring the solvent to the required ionic concentration.  Must be a
+          positive and negative monoatomic ions, default `None`
         neutralize : bool, optional
-          if the net charge on the chemical state is neutralized by the ions in this
-          solvent component.  Default `True`
-        concentration : openff-units.unit.Quantity, optional
+          if the net charge on the chemical state is neutralized by the ions in
+          this solvent component.  Default `True`
+        ion_concentration : openff-units.unit.Quantity, optional
           ionic concentration required, default `None`
           this must be supplied with units, e.g. "1.5 * unit.molar"
+
+        Examples
+        --------
+        To create a sodium chloride solution at 0.2 molar concentration::
+
+          >>> s = SolventComponent(ions=('Na', 'Cl'),
+          ...                      ion_concentration=0.2 * unit.molar)
+
         """
         self._smiles = smiles
         if ions is not None:
-            # strip and sort so that ('Na', 'Cl-') is equivalent to
-            # ('Cl', 'Na+')
-            self._ions = tuple(sorted(i.strip('+-').capitalize()
-                                      for i in ions))
+            # normalize: strip, sort and capitalize so that ('Na', 'Cl-') is
+            # equivalent to ('Cl', 'Na+')
+            norm_ions = tuple(sorted(i.strip('+-').capitalize() for i in ions))
+            # check ions make sense
+            if len(norm_ions) != 2:
+                raise ValueError(f"Must specify exactly two ions, got {ions}")
+            n_positive = sum(1 for i in norm_ions if i in _CATIONS)
+            n_negative = sum(1 for i in norm_ions if i in _ANIONS)
+            if n_positive != 1:
+                raise ValueError(f"Must give one positive ion, got {ions}")
+            if n_negative != 1:
+                raise ValueError(f"Must give one negative ion, got {ions}")
+            # mypy gets confused here...
+            self._ions = norm_ions  # type: ignore
         else:
-            self._ions = tuple()
+            self._ions = None
         self._neutralize = neutralize
-        self._concentration = concentration
+        if ion_concentration is not None:
+            if (not isinstance(ion_concentration, unit.Quantity) or
+               not ion_concentration.is_compatible_with(unit.molar)):
+                raise ValueError(f"ion_concentration must be given in units of"
+                                 f" concentration, got {ion_concentration}")
+        self._ion_concentration = ion_concentration
 
     @property
     def smiles(self) -> str:
@@ -52,7 +84,7 @@ class SolventComponent(Component):
         return self._smiles
 
     @property
-    def ions(self) -> Tuple[str, ...]:
+    def ions(self) -> Optional[tuple[str, str]]:
         """The ions in the solvent state"""
         return self._ions
 
@@ -62,9 +94,9 @@ class SolventComponent(Component):
         return self._neutralize
 
     @property
-    def concentration(self) -> unit.Quantity:
+    def ion_concentration(self) -> unit.Quantity:
         """Concentration of ions in the solvent state"""
-        return self._concentration
+        return self._ion_concentration
 
     @property
     def total_charge(self):
@@ -75,12 +107,12 @@ class SolventComponent(Component):
         try:
             return (self.smiles == other.smiles and
                     self.ions == other.ions and
-                    self.concentration == other.concentration)
+                    self.ion_concentration == other.ion_concentration)
         except AttributeError:
             return False
 
     def __hash__(self):
-        return hash((self.smiles, self.ions, self.concentration))
+        return hash((self.smiles, self.ions, self.ion_concentration))
 
     @classmethod
     def from_dict(cls, d):
@@ -90,5 +122,5 @@ class SolventComponent(Component):
     def to_dict(self):
         """For serialization"""
         return {'smiles': self.smiles, 'ions': self.ions,
-                'concentration': self.concentration,
+                'ion_concentration': self.ion_concentration,
                 'neutralize': self._neutralize}

--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -1,7 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 from openff.units import unit
-from typing import Optional
+from typing import Optional, Tuple
 
 from gufe import Component
 
@@ -19,13 +19,13 @@ class SolventComponent(Component):
     by specific MD engine methods.
     """
     _smiles: str
-    _ions: Optional[tuple[str, str]]
+    _ions: Optional[Tuple[str, str]]
     _neutralize: bool
     _ion_concentration: unit.Quantity
 
     def __init__(self, *,  # force kwarg usage
                  smiles: str = 'O',
-                 ions: tuple[str, str] = None,
+                 ions: Tuple[str, str] = None,
                  neutralize: bool = True,
                  ion_concentration: unit.Quantity = None):
         """
@@ -84,7 +84,7 @@ class SolventComponent(Component):
         return self._smiles
 
     @property
-    def ions(self) -> Optional[tuple[str, str]]:
+    def ions(self) -> Optional[Tuple[str, str]]:
         """The ions in the solvent state"""
         return self._ions
 

--- a/gufe/tests/test_chemicalsystem.py
+++ b/gufe/tests/test_chemicalsystem.py
@@ -14,7 +14,7 @@ def prot_comp(PDB_181L_path):
 
 @pytest.fixture
 def solv_comp():
-    yield gufe.SolventComponent(ions=('K', 'Cl'))
+    yield gufe.SolventComponent(positive_ion='K', negative_ion='Cl')
 
 
 @pytest.fixture

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -23,7 +23,8 @@ def test_hash(pos, neg):
 
     assert s1 == s2
     assert hash(s1) == hash(s2)
-
+    assert s2.positive_ion == 'Na+'
+    assert s2.negative_ion == 'Cl-'
 
 def test_neq():
     s1 = SolventComponent(positive_ion='Na', negative_ion='Cl')
@@ -36,8 +37,8 @@ def test_to_dict():
     s = SolventComponent(positive_ion='Na', negative_ion='Cl')
 
     assert s.to_dict() == {'smiles': 'O',
-                           'positive_ion': 'Na',
-                           'negative_ion': 'Cl',
+                           'positive_ion': 'Na+',
+                           'negative_ion': 'Cl-',
                            'neutralize': True,
                            'ion_concentration': None}
 

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -8,8 +8,8 @@ def test_defaults():
     s = SolventComponent()
 
     assert s.smiles == 'O'
-    assert s.ions == tuple()
-    assert s.concentration is None
+    assert s.ions is None
+    assert s.ion_concentration is None
 
 
 @pytest.mark.parametrize('other,', [
@@ -36,24 +36,45 @@ def test_to_dict():
 
     assert s.to_dict() == {'smiles': 'O', 'ions': ('Cl', 'Na'),
                            'neutralize': True,
-                           'concentration': None}
+                           'ion_concentration': None}
 
 
 def test_from_dict():
     s1 = SolventComponent(ions=('Na', 'Cl'),
-                          concentration=1.75 * unit.molar,
+                          ion_concentration=1.75 * unit.molar,
                           neutralize=False)
 
     assert SolventComponent.from_dict(s1.to_dict()) == s1
 
 
 def test_conc():
-    s = SolventComponent(ions=('Na', 'Cl'), concentration=1.75 * unit.molar)
+    s = SolventComponent(ions=('Na', 'Cl'),
+                         ion_concentration=1.75 * unit.molar)
 
-    assert s.concentration == unit.Quantity('1.75 M')
+    assert s.ion_concentration == unit.Quantity('1.75 M')
+
+
+@pytest.mark.parametrize('conc,',
+                         [1.22,  # no units, 1.22 what?
+                          1.5 * unit.kg])  # probably a tad much salt
+def test_bad_conc(conc):
+    with pytest.raises(ValueError):
+        _ = SolventComponent(ions=('Na', 'Cl'), ion_concentration=conc)
 
 
 def test_solvent_charge():
-    s = SolventComponent(ions=('Na', 'Cl'), concentration=1.75 * unit.molar)
+    s = SolventComponent(ions=('Na', 'Cl'),
+                         ion_concentration=1.75 * unit.molar)
 
     assert s.total_charge is None
+
+
+@pytest.mark.parametrize('ions,', [
+    ('Na',),
+    ('Cl', 'Cl'),
+    ('F', 'I')
+])
+def test_bad_inputs(ions):
+    print(ions)
+    with pytest.raises(ValueError):
+        _ = SolventComponent(ions=ions)


### PR DESCRIPTION
- if given, must give exactly two ions, one position one negative
- force use of kwargs to initialize
- rename concentation to ion_concentration
- added usage example
- allows ions=None rather than empty tuple