### PR TITLE
(WIP) Stable object hashes

### DIFF
--- a/gufe/component.py
+++ b/gufe/component.py
@@ -2,17 +2,36 @@
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
 import abc
+import hashlib
 from typing import Union
 
 
 class Component(abc.ABC):
     """Base class for members of a ChemicalSystem"""
-    @abc.abstractmethod
+
+    # defining this here doesn't actually allow subclasses to inherit, see:
+    #  see https://bugs.python.org/issue1549
     def __hash__(self):
-        pass
+        # in python hash(str) isn't deterministic (by design)
+        # to provide a stable hash across sessions:
+        # generate the string representation of this component
+        # (the definition of this string left to individual components)
+        s = str(self)
+
+        # pass this through a (fast) stable hash algorithm
+        hasher = hashlib.blake2b()
+        hasher.update(s.encode('utf-8'))
+        dig = hasher.digest()
+
+        # return big endian int representation of the first 8 bytes
+        return int.from_bytes(dig[:8], byteorder='big')
 
     def __lt__(self, other):
         return hash(self) < hash(other)
+
+    @abc.abstractmethod
+    def __str__(self):
+        ...
 
     @abc.abstractmethod
     def __eq__(self, other):

--- a/gufe/proteincomponent.py
+++ b/gufe/proteincomponent.py
@@ -34,6 +34,10 @@ class ProteinComponent(Component):
         self._openmm_pos = openmm_pos
         self._name = name
 
+    def __str__(self):
+        # TODO
+        return self._name
+
     @property
     def name(self):
         return self._name
@@ -78,11 +82,10 @@ class ProteinComponent(Component):
     def from_dict(cls, d: dict):
         raise NotImplementedError()
 
-    def __hash__(self):
-        return hash(self.name)
+    __hash__ = Component.__hash__
 
     def __eq__(self, other):
-        return hash(self) == hash(other)
+        return str(self) == str(other)
 
     @property
     def total_charge(self):

--- a/gufe/smallmoleculecomponent.py
+++ b/gufe/smallmoleculecomponent.py
@@ -82,6 +82,9 @@ class SmallMoleculeComponent(Component, Serializable):
         self._rdkit = rdkit
         self._hash = hashmol(self._rdkit, name=name)
 
+    def __str__(self):
+        return self.to_sdf()
+
     def to_rdkit(self) -> RDKitMol:
         """Return an RDKit copied representation of this molecule"""
         return Chem.Mol(self._rdkit)
@@ -119,11 +122,10 @@ class SmallMoleculeComponent(Component, Serializable):
     def name(self) -> str:
         return self._hash.name
 
-    def __hash__(self):
-        return hash(self._hash)
+    __hash__ = Component.__hash__
 
     def __eq__(self, other):
-        return hash(self) == hash(other)
+        return str(self) == str(other)
 
     def to_dict(self) -> dict:
         """Serialize to dict representation"""

--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -2,6 +2,7 @@
 # For details, see https://github.com/OpenFreeEnergy/gufe
 from __future__ import annotations
 
+import json
 from openff.units import unit
 from typing import Optional, Tuple
 
@@ -82,6 +83,8 @@ class SolventComponent(Component):
                     raise ValueError("Ions must be given for concentration")
         self._ion_concentration = ion_concentration
 
+    __hash__ = Component.__hash__
+
     @property
     def smiles(self) -> str:
         """SMILES representation of the solvent molecules"""
@@ -120,9 +123,8 @@ class SolventComponent(Component):
                 self.negative_ion == other.negative_ion and
                 self.ion_concentration == other.ion_concentration)
 
-    def __hash__(self):
-        return hash((self.smiles, self.positive_ion, self.negative_ion,
-                     self.ion_concentration))
+    def __str__(self):
+        return json.dumps(self.to_dict())
 
     @classmethod
     def from_dict(cls, d):


### PR DESCRIPTION
Fixes #22 

added str methods to components
- can just call `str(c)` to get something useful out
- for SmallMoleculeComponent this is the sdf, for proteins likely the mmcif?  Is this useful or should we be more explicit

added stable hash method to components
- currently this uses blake2 as it was fastest, but maybe using md5 allows command line generation too (blake2 probably isn't built into terminals)
- this is an int representation of the first 8 bytes of the (blake2) hash.  This should also allow a foreign package to calculate the same hash, which might be useful...