### PR TITLE
added Failure result

### DIFF
--- a/gufe/protocols/__init__.py
+++ b/gufe/protocols/__init__.py
@@ -1,4 +1,4 @@
 from .protocol import Protocol, ProtocolResult
-from .results import ProtocolUnitResult, ProtocolDAGResult
+from .results import ProtocolUnitResult, ProtocolUnitFailure, ProtocolDAGResult, ProtocolDAGFailure
 from .protocoldag import ProtocolDAG
 from .protocolunit import ProtocolUnit

--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -58,6 +58,8 @@ class ProtocolDAG:
                     for d in self._graph.successors(unit)
                 ]
             )
+            if not result.ok():
+                raise RuntimeError("Unit failed to execute")
             # attach results
             graph.nodes[unit]["result"] = result
 

--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -2,12 +2,12 @@
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
 import abc
-from typing import Iterable, List, Dict, Set, Optional
+from typing import Iterable, List, Dict, Set, Optional, Union
 
 import networkx as nx
 
 from .protocolunit import ProtocolUnit
-from .results import ProtocolDAGResult
+from .results import ProtocolDAGResult, ProtocolDAGFailure
 
 
 class ProtocolDAG:
@@ -45,7 +45,7 @@ class ProtocolDAG:
     def graph(self):
         return self._graph
 
-    def execute(self) -> ProtocolDAGResult:
+    def execute(self) -> Union[ProtocolDAGResult, ProtocolDAGFailure]:
         """Execute the full DAG in-serial, in process."""
         # operate on a copy, since we'll add ProtocolUnitResults as node attributes
         graph = self._graph.copy(as_view=False)
@@ -58,9 +58,10 @@ class ProtocolDAG:
                     for d in self._graph.successors(unit)
                 ]
             )
-            if not result.ok():
-                raise RuntimeError("Unit failed to execute")
             # attach results
             graph.nodes[unit]["result"] = result
+
+            if not result.ok():
+                return ProtocolDAGFailure(name=self._name, graph=graph)
 
         return ProtocolDAGResult(name=self._name, graph=graph)

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -10,7 +10,9 @@ import abc
 from os import PathLike
 from typing import Iterable, List, Dict, Any, Optional
 
-from .results import ProtocolUnitResult
+from .results import (
+    ProtocolUnitResult, ProtocolUnitCompletion, ProtocolUnitFailure,
+)
 
 
 class ProtocolUnit(abc.ABC):
@@ -50,14 +52,20 @@ class ProtocolUnit(abc.ABC):
         block : bool
             If `True`, block until execution completes; otherwise run in its own thread.
         dependency_results :
-
+            the
         """
         if block:
-            out = self._execute(dependency_results)
-            result = ProtocolUnitResult(
-                name=self._name, dependencies=dependency_results, **out
-            )
-
+            try:
+                out = self._execute(dependency_results)
+                result = ProtocolUnitResult(
+                    name=self._name, dependencies=dependency_results, **out
+                )
+            except Exception as e:
+                result = ProtocolUnitFailure(
+                    name=self._name,
+                    depedencies=dependency_results,
+                    exception=e,
+                )
         else:
             # TODO: wrap in a thread; update status
             ...

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -49,15 +49,15 @@ class ProtocolUnit(abc.ABC):
 
         Parameters
         ----------
+        dependency_results : Iterable[ProtocolUnitResult]
+            The `ProtocolUnitResult`s from the `ProtocolUnit`s this unit is dependent on.
         block : bool
             If `True`, block until execution completes; otherwise run in its own thread.
-        dependency_results :
-            the
         """
         if block:
             try:
                 out = self._execute(dependency_results)
-                result = ProtocolUnitResult(
+                result = ProtocolUnitCompletion(
                     name=self._name, dependencies=dependency_results, **out
                 )
             except Exception as e:

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -8,15 +8,15 @@ part of a `ProtocolDAG`.
 
 import abc
 from os import PathLike
-from typing import Iterable, List, Dict, Any, Optional
+from typing import Iterable, List, Dict, Any, Optional, Union
 
 from .results import (
-    ProtocolUnitResult, ProtocolUnitCompletion, ProtocolUnitFailure,
+    ProtocolUnitResult, ProtocolUnitFailure,
 )
 
 
 class ProtocolUnit(abc.ABC):
-    """A unit of work computable by"""
+    """A unit of work within a `ProtocolDAG`"""
 
     def __init__(
         self,
@@ -24,7 +24,6 @@ class ProtocolUnit(abc.ABC):
         name: Optional[str] = None,
         **kwargs
     ):
-
         self._settings = settings
         self._kwargs = kwargs
         self._name = name
@@ -44,7 +43,7 @@ class ProtocolUnit(abc.ABC):
 
     def execute(
         self, dependency_results: Iterable[ProtocolUnitResult], block=True
-    ) -> ProtocolUnitResult:
+    ) -> Union[ProtocolUnitResult, ProtocolUnitFailure]:
         """Given `ProtocolUnitResult`s from dependencies, execute this `ProtocolUnit`.
 
         Parameters
@@ -57,7 +56,7 @@ class ProtocolUnit(abc.ABC):
         if block:
             try:
                 out = self._execute(dependency_results)
-                result = ProtocolUnitCompletion(
+                result = ProtocolUnitResult(
                     name=self._name, dependencies=dependency_results, **out
                 )
             except Exception as e:

--- a/gufe/protocols/results.py
+++ b/gufe/protocols/results.py
@@ -35,10 +35,12 @@ class ProtocolUnitResult(BaseModel, abc.ABC):
         """
         Parameters
         ----------
-        dependencies : list, optional
-          the predecessors of the creating ProtocolUnit
-        data : dict, optional
-          all other kwargs get stored as the output of a ProtocolUnit
+        dependencies : Optional[Iterable["ProtocolUnitResult"]]
+          The `ProtocolUnitResult`s from the predecessors of the `ProtocolUnit`
+          that creates this `ProtocolUnitResult`.
+        **data
+          All other keyword arguments are retained as attributes of this
+          `ProtocolUnitResult`.
         """
 
         if dependencies is None:

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -109,6 +109,44 @@ class DummyProtocol(Protocol):
 
         return dict(data=outputs)
 
+class BrokenSimulationUnit(SimulationUnit):
+    def _execute(self, dependency_results):
+        raise ValueError("I have failed my mission", {'data': 'lol'})
+
+
+class BrokenProtocol(DummyProtocol):
+    def _create(
+        self,
+        stateA: ChemicalSystem,
+        stateB: ChemicalSystem,
+        mapping: Optional[Mapping] = None,
+        extend_from: Optional[ProtocolDAGResult] = None,
+    ) -> nx.DiGraph:
+
+        alpha = InitializeUnit(
+            self.settings,
+            stateA=stateA,
+            stateB=stateB,
+            mapping=mapping,
+            start=extend_from,
+        )
+
+        simulations: List[ProtocolUnit] = [
+            SimulationUnit(self.settings, window=i) for i in range(20)
+        ]
+
+        # introduce a broken ProtocolUnit
+        simulations.append(BrokenSimulationUnit(self.settings, window=20, name="problem child"))
+
+        omega = FinishUnit(self.settings, name="the end")
+
+        dag = nx.DiGraph()
+        for sim in simulations:
+            dag.add_edge(sim, alpha)
+            dag.add_edge(omega, sim)
+
+        return dag
+
 
 class TestProtocol:
     def test_init(self):
@@ -124,6 +162,8 @@ class TestProtocol:
             stateA=solvated_ligand, stateB=solvated_complex, name="a dummy run"
         )
         dagresult = dag.execute()
+
+        assert dagresult.ok()
 
         finishresult = [
             dagresult.graph.nodes[u]["result"]
@@ -147,3 +187,24 @@ class TestProtocol:
 
         assert len(protocolresult.data) == 1
         assert len(protocolresult.data[0]) == 20 + 1
+
+    def test_create_execute_failure(self, solvated_ligand, solvated_complex):
+        protocol = BrokenProtocol(settings=None)
+
+        dag = protocol.create(
+            stateA=solvated_ligand, stateB=solvated_complex, name="a broken dummy run"
+        )
+
+        dagfailure = dag.execute()
+
+        assert not dagfailure.ok()
+
+        failed_units = dagfailure.protocol_unit_failures
+
+        assert len(failed_units) == 1
+        assert failed_units[0].name == "problem child"
+        assert failed_units[0].exception.args[1]['data'] == "lol"
+
+        succeeded_units = dagfailure.protocol_unit_results
+
+        assert len(succeeded_units) > 0

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -14,7 +14,9 @@ from gufe.protocols import (
     ProtocolUnit,
     ProtocolResult,
     ProtocolDAGResult,
+    ProtocolDAGFailure,
     ProtocolUnitResult,
+    ProtocolUnitFailure,
 )
 
 
@@ -198,12 +200,14 @@ class TestProtocol:
         dagfailure = dag.execute()
 
         assert not dagfailure.ok()
+        assert isinstance(dagfailure, ProtocolDAGFailure)
 
         failed_units = dagfailure.protocol_unit_failures
 
         assert len(failed_units) == 1
         assert failed_units[0].name == "problem child"
         assert failed_units[0].exception.args[1]['data'] == "lol"
+        assert isinstance(failed_units[0], ProtocolUnitFailure)
 
         succeeded_units = dagfailure.protocol_unit_results
 


### PR DESCRIPTION
I think it might make sense for the result of an individual piece of work to return either a "good" or "bad" results object.  I think Exceptions are enough for some failure reasons (out of disk space, incomplete inputs, unsuitable compute environment) but by returning more than just an exception, you could make the chemistry failures a lot more useful.

It could be that we can make the `ok()` method below just an attribute of a single Result class, since the schema for a `ProtocolUnitResult` is fairly loose/nonexistant.  I'm undecided if there's value in having two schema, one for results and one for error introspection.

One annoyance of first class errors is we'd have to teach schedulers how to identify these so they correctly interrupt a dependency chain.  I think there's probably a class of errors that we don't swallow and pass onto the scheduler directly, and it can probably have a good crack at rerunning them, and there's probably a class of chemistry errors which are fatal.