### PR TITLE
Fix coveragerc ellipsis exclusion

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,4 +9,4 @@ exclude_lines =
     pragma: no-cover
     -no-cov
     raise NotImplementedError
-    ...
+    \.\.\.


### PR DESCRIPTION
`exclude_lines` in `.coveragerc` is a list of regular expressions, not literal strings. Therefore including the string `...` caused all lines to be excluded from coverage. This fixes the problem.