### PR TITLE
to_dict on unitted quantities should use to_tuple

### DIFF
--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -131,11 +131,19 @@ class SolventComponent(Component):
     @classmethod
     def from_dict(cls, d):
         """Deserialize from dict representation"""
+        ion_conc = d['ion_concentration']
+        if ion_conc:
+            d['ion_concentration'] = unit.Quantity.from_tuple(ion_conc)
+
         return cls(**d)
 
     def to_dict(self):
         """For serialization"""
+        ion_conc = self.ion_concentration
+        if ion_conc:
+            ion_conc = ion_conc.to_tuple()
+
         return {'smiles': self.smiles, 'positive_ion': self.positive_ion,
                 'negative_ion': self.negative_ion,
-                'ion_concentration': self.ion_concentration,
+                'ion_concentration': ion_conc,
                 'neutralize': self._neutralize}

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -43,9 +43,10 @@ def test_to_dict():
                            'ion_concentration': None}
 
 
-def test_from_dict():
+@pytest.mark.parametrize(conc, [None, 1.75 * unit.molar])
+def test_from_dict(conc):
     s1 = SolventComponent(positive_ion='Na', negative_ion='Cl',
-                          ion_concentration=1.75 * unit.molar,
+                          ion_concentration=conc,
                           neutralize=False)
 
     assert SolventComponent.from_dict(s1.to_dict()) == s1

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -43,7 +43,7 @@ def test_to_dict():
                            'ion_concentration': None}
 
 
-@pytest.mark.parametrize(conc, [None, 1.75 * unit.molar])
+@pytest.mark.parametrize('conc', [None, 1.75 * unit.molar])
 def test_from_dict(conc):
     s1 = SolventComponent(positive_ion='Na', negative_ion='Cl',
                           ion_concentration=conc,


### PR DESCRIPTION
Life is a lot easier if we play by the rule that the dict that comes out of to_dict should be JSON serializable. Quantities are not.

Choice is either create custom JSON encoders/decoders, or require to_dict to return something JSON serialization.

In this PR, I only changed SolventComponent.ion_concentration. I may come across others as I work my way through storage.