### PR TITLE
Change ion defaults

### DIFF
--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -28,8 +28,8 @@ class SolventComponent(Component):
 
     def __init__(self, *,  # force kwarg usage
                  smiles: str = 'O',
-                 positive_ion: Optional[str] = None,
-                 negative_ion: Optional[str] = None,
+                 positive_ion: Optional[str] = 'Na+',
+                 negative_ion: Optional[str] = 'Cl-',
                  neutralize: bool = True,
                  ion_concentration: unit.Quantity = None):
         """
@@ -40,7 +40,7 @@ class SolventComponent(Component):
         positive_ion, negative_ion : str, optional
           the pair of ions which is used to neutralize (if neutralize=True) and
           bring the solvent to the required ionic concentration.  Must be a
-          positive and negative monoatomic ions, default `None`
+          positive and negative monoatomic ions, defaults "Na+", "Cl-"
         neutralize : bool, optional
           if the net charge on the chemical state is neutralized by the ions in
           this solvent component.  Default `True`

--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -28,8 +28,8 @@ class SolventComponent(Component):
 
     def __init__(self, *,  # force kwarg usage
                  smiles: str = 'O',
-                 positive_ion: Optional[str] = 'Na+',
-                 negative_ion: Optional[str] = 'Cl-',
+                 positive_ion: str = 'Na+',
+                 negative_ion: str = 'Cl-',
                  neutralize: bool = True,
                  ion_concentration: unit.Quantity = None):
         """
@@ -37,7 +37,7 @@ class SolventComponent(Component):
         ----------
         smiles : str, optional
           smiles of the solvent, default 'O' (water)
-        positive_ion, negative_ion : str, optional
+        positive_ion, negative_ion : str
           the pair of ions which is used to neutralize (if neutralize=True) and
           bring the solvent to the required ionic concentration.  Must be a
           positive and negative monoatomic ions, defaults "Na+", "Cl-"
@@ -57,17 +57,15 @@ class SolventComponent(Component):
 
         """
         self._smiles = smiles
-        if positive_ion is not None:
-            norm = positive_ion.strip('-+').capitalize()
-            if norm not in _CATIONS:
-                raise ValueError(f"Invalid positive ion, got {positive_ion}")
-            positive_ion = norm + '+'
+        norm = positive_ion.strip('-+').capitalize()
+        if norm not in _CATIONS:
+            raise ValueError(f"Invalid positive ion, got {positive_ion}")
+        positive_ion = norm + '+'
         self._positive_ion = positive_ion
-        if negative_ion is not None:
-            norm = negative_ion.strip('-+').capitalize()
-            if norm not in _ANIONS:
-                raise ValueError(f"Invalid negative ion, got {negative_ion}")
-            negative_ion = norm + '-'
+        norm = negative_ion.strip('-+').capitalize()
+        if norm not in _ANIONS:
+            raise ValueError(f"Invalid negative ion, got {negative_ion}")
+        negative_ion = norm + '-'
         self._negative_ion = negative_ion
 
         self._neutralize = neutralize

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -8,8 +8,8 @@ def test_defaults():
     s = SolventComponent()
 
     assert s.smiles == 'O'
-    assert s.positive_ion is None
-    assert s.negative_ion is None
+    assert s.positive_ion == "Na+"
+    assert s.negative_ion == "Cl-"
     assert s.ion_concentration is None
 
 

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -81,13 +81,3 @@ def test_solvent_charge():
 def test_bad_inputs(pos, neg):
     with pytest.raises(ValueError):
         _ = SolventComponent(positive_ion=pos, negative_ion=neg)
-
-
-@pytest.mark.parametrize('pos, neg', [
-    ('Na', None), (None, 'Cl'), (None, None),
-])
-def test_conc_no_ions(pos, neg):
-    # if you specify concentration you must also give ions
-    with pytest.raises(ValueError):
-        _ = SolventComponent(positive_ion=pos, negative_ion=neg,
-                             ion_concentration=1.5 * unit.molar)


### PR DESCRIPTION
If both ions are `None` and `neutralize=True` (as is the default) behavior is unclear if the system needs to be neutralized. This changes the defaults to "Na+" and "Cl-".

Second commit here disallows `None` as a valid value. I don't think there's any reason to allow it if it isn't the default, right?

While I'm at it, should I also change default on `ion_concentration` to 0.0 molar, instead of `None`? 