### PR TITLE
Add PerFileJSONMetadataStore

### DIFF
--- a/gufe/storage/metadatastore.py
+++ b/gufe/storage/metadatastore.py
@@ -7,7 +7,9 @@ import collections
 from typing import Tuple, Dict
 from .externalresource.base import Metadata
 
-from .errors import MissingExternalResourceError
+from .errors import (
+    MissingExternalResourceError, ChangedExternalResourceError
+)
 
 
 class MetadataStore(collections.abc.Mapping):
@@ -94,7 +96,7 @@ class PerFileJSONMetadataStore(MetadataStore):
 
                 if set(dct) != {"path", "md5"}:
                     raise ChangedExternalResourceError("Bad metadata file: "
-                                                       f"'{filename}'")
+                                                       f"'{location}'")
                 metadata_cache[dct['path']] = dct['md5']
 
         return metadata_cache

--- a/gufe/storage/metadatastore.py
+++ b/gufe/storage/metadatastore.py
@@ -76,12 +76,12 @@ class PerFileJSONMetadataStore(MetadataStore):
     def _metadata_path(self, location):
         return self._metadata_prefix + location + ".json"
 
-    def store_metadata(self, location: str, metadata: str):
+    def store_metadata(self, location: str, metadata: Metadata):
         self._metadata_cache[location] = metadata
         path = self._metadata_path(location)
         dct = {
             'path': location,
-            'md5': metadata,
+            'metadata': metadata.to_dict(),
         }
         metadata_bytes = json.dumps(dct).encode('utf-8')
         self.external_store.store_bytes(path, metadata_bytes)
@@ -94,10 +94,10 @@ class PerFileJSONMetadataStore(MetadataStore):
                 with self.external_store.load_stream(location) as f:
                     dct = json.loads(f.read().decode('utf-8'))
 
-                if set(dct) != {"path", "md5"}:
+                if set(dct) != {"path", "metadata"}:
                     raise ChangedExternalResourceError("Bad metadata file: "
                                                        f"'{location}'")
-                metadata_cache[dct['path']] = dct['md5']
+                metadata_cache[dct['path']] = Metadata(**dct['metadata'])
 
         return metadata_cache
 

--- a/gufe/storage/metadatastore.py
+++ b/gufe/storage/metadatastore.py
@@ -87,9 +87,11 @@ class PerFileJSONMetadataStore(MetadataStore):
     def load_all_metadata(self):
         metadata_cache = {}
         prefix = self._metadata_prefix
-        for filename in self.external_store.iter_contents(prefix=prefix):
-            if filename.endswith(".json"):
-                dct = json.load(filename)
+        for location in self.external_store.iter_contents(prefix=prefix):
+            if location.endswith(".json"):
+                with self.external_store.load_stream(location) as f:
+                    dct = json.loads(f.read().decode('utf-8'))
+
                 if set(dct) != {"path", "md5"}:
                     raise ChangedExternalResourceError("Bad metadata file: "
                                                        f"'{filename}'")

--- a/gufe/tests/storage/test_metadatastore.py
+++ b/gufe/tests/storage/test_metadatastore.py
@@ -25,7 +25,7 @@ def json_metadata(tmpdir):
 @pytest.fixture
 def per_file_metadata(tmp_path):
     metadata_dict = {'path': 'path/to/foo.txt',
-                     'md5': 'bar'}
+                     'metadata': {'md5': 'bar'}}
     external_store = FileStorage(str(tmp_path))
     metadata_loc = 'metadata/path/to/foo.txt.json'
     metadata_path = tmp_path / pathlib.Path(metadata_loc)
@@ -118,10 +118,11 @@ class TestPerFileJSONMetadataStore(MetadataTests):
         root = per_file_metadata.external_store.root_dir
         expected_path = root / expected_loc
         assert not expected_path.exists()
-        per_file_metadata.store_metadata("path/to/other.txt", "other")
+        meta = Metadata(md5="other")
+        per_file_metadata.store_metadata("path/to/other.txt", meta)
         assert expected_path.exists()
         expected = {'path': "path/to/other.txt",
-                    'md5': "other"}
+                    'metadata': {"md5": "other"}}
         with open(expected_path, mode='r')as f:
             assert json.load(f) == expected
 

--- a/gufe/tests/storage/test_metadatastore.py
+++ b/gufe/tests/storage/test_metadatastore.py
@@ -134,4 +134,3 @@ class TestPerFileJSONMetadataStore:
 
     def test_getitem(self, per_file_metadata):
         self._test_getitem(per_file_metadata)
-

--- a/gufe/tests/storage/test_metadatastore.py
+++ b/gufe/tests/storage/test_metadatastore.py
@@ -151,7 +151,3 @@ class TestPerFileJSONMetadataStore(MetadataTests):
         with pytest.raises(ChangedExternalResourceError,
                            match="Bad metadata"):
             PerFileJSONMetadataStore(FileStorage(tmp_path))
-
-
-
-

--- a/gufe/tests/storage/test_metadatastore.py
+++ b/gufe/tests/storage/test_metadatastore.py
@@ -50,7 +50,7 @@ class MetadataTests:
         raise NotImplementedError("This should call self._test_delete")
 
     def _test_load_all_metadata(self, metadata):
-        expected = {'path/to/foo.txt': 'bar'}
+        expected = {'path/to/foo.txt': Metadata(md5='bar')}
         metadata._metadata_cache = {}
         loaded = metadata.load_all_metadata()
         assert loaded == expected
@@ -69,7 +69,7 @@ class MetadataTests:
         assert len(metadata) == 1
 
     def _test_getitem(self, metadata):
-        assert metadata["path/to/foo.txt"] == "bar"
+        assert metadata["path/to/foo.txt"] == Metadata(md5="bar")
 
 
 class TestJSONMetadataStore(MetadataTests):

--- a/gufe/tests/storage/test_metadatastore.py
+++ b/gufe/tests/storage/test_metadatastore.py
@@ -7,7 +7,9 @@ from gufe.storage.metadatastore import (
 )
 from gufe.storage.externalresource import FileStorage
 from gufe.storage.externalresource.base import Metadata
-from gufe.storage.errors import MissingExternalResourceError
+from gufe.storage.errors import (
+    MissingExternalResourceError, ChangedExternalResourceError
+)
 
 
 @pytest.fixture
@@ -138,3 +140,18 @@ class TestPerFileJSONMetadataStore(MetadataTests):
 
     def test_getitem(self, per_file_metadata):
         self._test_getitem(per_file_metadata)
+
+    def test_bad_metadata_contents(self, tmp_path):
+        loc = tmp_path / "metadata/foo.txt.json"
+        loc.parent.mkdir(parents=True, exist_ok=True)
+        bad_dict = {'foo': 'bar'}
+        with open(loc, mode='wb') as f:
+            f.write(json.dumps(bad_dict).encode('utf-8'))
+
+        with pytest.raises(ChangedExternalResourceError,
+                           match="Bad metadata"):
+            PerFileJSONMetadataStore(FileStorage(tmp_path))
+
+
+
+


### PR DESCRIPTION
(This includes and extends #21, and should be merged/reviewed after that one is merged.)

This adds `PerFileJSONMetadataStore`. The original `JSONMetadataStore` wrote all metadata (hashes) to a single JSON file. That is unlikely to be optimal for many workflows. The approach used in this object creates a separate label at `metadata/{filename}.json`, corresponding to a JSON file with an object carrying the metadata. This way, we don't need to completely re-export all metadata every time we store an new object.