### PR TITLE
Serialization and tokenization via GufeTokenizableMixin

### DIFF
--- a/gufe/base.py
+++ b/gufe/base.py
@@ -1,0 +1,108 @@
+import abc
+import uuid
+import sys
+import threading
+import hashlib
+import inspect
+from packaging.version import parse as parse_version
+from typing import Dict, Any, Callable
+
+
+class GufeTokenizableMixin:
+    """Mixin for all tokenizble tokenizeable gufe objects.
+
+    """
+
+    @property
+    def token(self):
+        if not hasattr(self, '_token') or self._token is None:
+            self._token = tokenize(self)
+        return self._token
+
+    @property
+    def key(self):
+        if not hasattr(self, '_key') or self._key is None:
+            prefix = type(self).__name__
+            self._key = GufeKey(f"{prefix}-{self.token}")
+        return self._key
+
+    @property
+    def defaults(self):
+        sig = inspect.signature(self.__init__)
+
+        defaults = {
+            param.name: param.default for param in sig.parameters.values()
+            if param.default is not inspect.Parameter.empty
+        }
+
+        return defaults
+
+    def _keyencode_dependencies(self, d):
+        for key, value in d.items():
+            if isinstance(value, dict):
+                self._keyencode_dependencies(value)
+            elif isinstance(value, list):
+                for i, item in enumerate(value):
+                    if hasattr(item, '_gufe_tokenize'):
+                        d[key][i] = item
+            else:
+                if hasattr(value, '_gufe_tokenize'):
+                    d[key] = value.token
+
+        return d
+
+
+class GufeKey(str):
+    def __repr__(self):
+        return f"<GufeKey('{str(self)}')>"
+
+
+STUBBED_OBJECT_REGISTRY: Dict[str, GufeTokenizableMixin] = {}
+"""Registry of token-stubbed objects.
+
+Used to avoid duplication of tokenizable `gufe` objects in memory when deserialized.
+Each key is a token, each value the token-stubbed version of the object
+corresponding to that token.
+
+"""
+
+#TODO see if you can proceed without this first
+#STUBBED_OBJECT_REGISTRY_REVERSE: Dict[GufeTokenizableMixin, str] = {}
+#"""Reverse registry of token-stubbed objects.
+#
+#Used to Avoid duplication of tokenizable `gufe` objects in memory when deserialized.
+#Each key is a token-stubbed version of a `gufe` object, and each value is a 
+#token corresponding to that object.
+#
+#"""
+
+
+# FROM dask.base
+
+# Pass `usedforsecurity=False` for Python 3.9+ to support FIPS builds of Python
+_PY_VERSION = parse_version(".".join(map(str, sys.version_info[:3])))
+_md5: Callable
+if _PY_VERSION >= parse_version("3.9"):
+
+    def _md5(x, _hashlib_md5=hashlib.md5):
+        return _hashlib_md5(x, usedforsecurity=False)
+
+else:
+    _md5 = hashlib.md5
+
+NORMALIZERS = {}
+
+def normalize_object(o):
+    method = getattr(o, "_gufe_tokenize", None)
+    if method is not None:
+        return method()
+    else:
+        raise ValueError("Cannot normalize without `_gufe_tokenize` method.")
+
+
+def tokenize(arg):
+    """Deterministic token"""
+    hasher = _md5(str(normalize_object(arg)).encode())
+    return hasher.hexdigest()
+
+

--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -7,10 +7,11 @@ from typing import Dict, Optional
 import numpy as np
 from openff.toolkit.utils.serialization import Serializable
 
-from .component import Component
+from .base import GufeTokenizableMixin, normalize_object
+from .component import Component, from_dict as component_from_dict
 
 
-class ChemicalSystem(Serializable, abc.Mapping):
+class ChemicalSystem(abc.Mapping, GufeTokenizableMixin):
     """A node of an alchemical network.
 
     Attributes
@@ -93,8 +94,9 @@ class ChemicalSystem(Serializable, abc.Mapping):
 
     # TODO: broken without a `Component` registry of some kind
     # should then be changed to use the registry
-    def to_dict(self):
+    def _to_dict(self):
         return {
+            "__class__": self.__class__.__name__,
             "components": {
                 key: value.to_dict() for key, value in self.components.items()
             },
@@ -105,7 +107,7 @@ class ChemicalSystem(Serializable, abc.Mapping):
     # TODO: broken without a `Component` registry of some kind
     # should then be changed to use the registry
     @classmethod
-    def from_dict(cls, d):
+    def _from_dict(cls, d):
         return cls(
             components={
                 key: Component.from_dict(value) for key, value in d["components"]

--- a/gufe/component.py
+++ b/gufe/component.py
@@ -4,37 +4,103 @@
 import abc
 from typing import Union
 
+from .base import GufeTokenizableMixin
 
-class Component(abc.ABC):
+
+COMPONENT_REGISTRY = {}
+
+def register_component(cls):
+    COMPONENT_REGISTRY[cls.__name__] = cls
+
+    
+class _ComponentMeta(type):
+    def __new__(cls, name, bases, classdict):
+        componentcls = super().__new__(cls, name, bases, classdict)
+        register_component(componentcls)
+        return componentcls
+
+
+class _ABCComponentMeta(_ComponentMeta, abc.ABCMeta):
+    # required to make use of abc.ABC in classes that use _ComponentMeta metaclass
+    # see https://stackoverflow.com/questions/57349105/python-abc-inheritance-with-specified-metaclass 
+    ...
+        
+
+class Component(abc.ABC, GufeTokenizableMixin, metaclass=_ABCComponentMeta):
     """Base class for members of a ChemicalSystem"""
+
+    def __init__(self):
+
+        # since __hash__ isn't inheritable, monkey-patching is the best we can
+        # do besides defining it in every subclass
+        self.__class__.__hash__ = Component.__hash__
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name={self.name})"
 
-    @abc.abstractmethod
-    def __hash__(self):
-        pass
-
     def __lt__(self, other):
         return hash(self) < hash(other)
 
-    @abc.abstractmethod
     def __eq__(self, other):
-        pass
+        if not isinstance(other, self.__class__):
+            return NotImplemented("Component comparisons must be of the same type")
 
-    @abc.abstractmethod
-    def to_dict(self) -> dict:
-        pass
+        d = self.to_dict()
+        do = other.to_dict()
+
+        if set(d.keys()) == set(do.keys()):
+            for key in d:
+                if d[key] != do[key]:
+                    return False
+
+            return True
+
+    def __hash__(self):
+        return hash(self.key)
+
+    def _gufe_tokenize(self):
+        """Return a list of normalized inputs for `gufe.base.tokenize`.
+
+        """
+        return sorted(self.to_dict(include_defaults=False).items(), key=str)
 
     @property
     @abc.abstractmethod
     def name(self) -> str:
         pass
 
-    @classmethod
+    def to_dict(self, include_defaults=True, keyencode_dependencies=False) -> dict:
+        """Serialize to dict representation"""
+
+        d = self._to_dict()
+        d['__class__'] = self.__class__.__name__
+
+        if keyencode_dependencies:
+            d = self._keyencode_dependencies(d)
+
+        if not include_defaults:
+            for key, value in self.defaults.items():
+                if d.get(key) == value:
+                    d.pop(key)
+
+        return d
+
     @abc.abstractmethod
-    def from_dict(cls, d: dict):
-        pass
+    def _to_dict(self) -> dict:
+        ...
+
+
+    def from_dict(cls, d: dict, keydecode_dependencies=False):
+        """Deserialize from dict representation"""
+        component_type = d.pop('__class__', None)
+        if component_type is None:
+            raise KeyError("No `__class__` key found; unable to deserialize Component")
+
+        return COMPONENT_REGISTRY[component_type]._from_dict(d)
+
+    @abc.abstractmethod
+    def _from_dict(cls, d: dict):
+        ...
 
     @property
     @abc.abstractmethod

--- a/gufe/smallmoleculecomponent.py
+++ b/gufe/smallmoleculecomponent.py
@@ -5,7 +5,6 @@ import logging
 logger = logging.getLogger('openff.toolkit')
 logger.setLevel(logging.ERROR)
 from openff.toolkit.topology import Molecule as OFFMolecule
-from openff.toolkit.utils.serialization import Serializable
 import warnings
 
 from rdkit import Chem
@@ -46,7 +45,7 @@ def _ensure_ofe_version(mol: RDKitMol):
     mol.SetProp("ofe-version", __version__)
 
 
-class SmallMoleculeComponent(Component, Serializable):
+class SmallMoleculeComponent(Component):
     """A molecule wrapper suitable for small molecules
 
     .. note::

--- a/gufe/solventcomponent.py
+++ b/gufe/solventcomponent.py
@@ -114,20 +114,29 @@ class SolventComponent(Component):
         """Solvents don't have a formal charge defined so this returns None"""
         return None
 
-    def __eq__(self, other):
-        if not isinstance(other, SolventComponent):
-            return NotImplemented
-        return (self.smiles == other.smiles and
-                self.positive_ion == other.positive_ion and
-                self.negative_ion == other.negative_ion and
-                self.ion_concentration == other.ion_concentration)
+    #def __eq__(self, other):
+    #    if not isinstance(other, SolventComponent):
+    #        return NotImplemented
+    #    return (self.smiles == other.smiles and
+    #            self.positive_ion == other.positive_ion and
+    #            self.negative_ion == other.negative_ion and
+    #            self.ion_concentration == other.ion_concentration)
 
-    def __hash__(self):
-        return hash((self.smiles, self.positive_ion, self.negative_ion,
-                     self.ion_concentration))
+    def _gufe_tokenize(self):
+        """Return a list of normalized inputs for `gufe.base.tokenize`.
+
+        """
+
+        return sorted(self.to_dict(include_defaults=False).items(), key=str)
+
+        #return [self.smiles,
+        #        self.positive_ion,
+        #        self.negative_ion,
+        #        self.ion_concentration.to_tuple(),
+        #        self.neutralize]
 
     @classmethod
-    def from_dict(cls, d):
+    def _from_dict(cls, d):
         """Deserialize from dict representation"""
         ion_conc = d['ion_concentration']
         if ion_conc:
@@ -135,7 +144,7 @@ class SolventComponent(Component):
 
         return cls(**d)
 
-    def to_dict(self):
+    def _to_dict(self):
         """For serialization"""
         ion_conc = self.ion_concentration
         if ion_conc:


### PR DESCRIPTION
This PR is an iteration on #30. 

In this approach, we implement tokenization as performed in `dask.base`, and put as much of the required machinery in `gufe.base.GufeTokenizableMixin`.

Every tokenizable `gufe` object should include this mixin.
When included, this provides the `.key` property, which is the stable identifier across platforms and Python sessions.
This is composed of `<classname>-<token>`, where `.token` is an MD5-hash of the non-default values included in the
`.to_dict(include_defaults=False, keyencode_dependencies=True)` form of the object.

We also include:
- a registry for `Component` subclasses (`gufe.component.COMPONENT_REGISTRY`); subclasses are automatically added on definition
- a registry for existing objects in memory, by key (`gufe.base.OBJECT_REGISTRY`)
