### PR TITLE
Solvent: make concentration always a unit, even if 0.0M

### DIFF
--- a/gufe/components/solventcomponent.py
+++ b/gufe/components/solventcomponent.py
@@ -31,7 +31,7 @@ class SolventComponent(Component):
                  positive_ion: str = 'Na+',
                  negative_ion: str = 'Cl-',
                  neutralize: bool = True,
-                 ion_concentration: unit.Quantity = None):
+                 ion_concentration: unit.Quantity = 0.0 * unit.molar):
         """
         Parameters
         ----------
@@ -69,15 +69,15 @@ class SolventComponent(Component):
         self._negative_ion = negative_ion
 
         self._neutralize = neutralize
-        if ion_concentration is not None:
-            if (not isinstance(ion_concentration, unit.Quantity) or
-               not ion_concentration.is_compatible_with(unit.molar)):
-                raise ValueError(f"ion_concentration must be given in units of"
-                                 f" concentration, got {ion_concentration}")
-            # concentration requires both ions be given
-            if ion_concentration > 0:
-                if self._negative_ion is None or self._positive_ion is None:
-                    raise ValueError("Ions must be given for concentration")
+
+        if (not isinstance(ion_concentration, unit.Quantity)
+           or not ion_concentration.is_compatible_with(unit.molar)):
+            raise ValueError(f"ion_concentration must be given in units of"
+                             f" concentration, got: {ion_concentration}")
+        if ion_concentration.m < 0:
+            raise ValueError(f"ion_concentration must be positive, "
+                             f"got: {ion_concentration}")
+
         self._ion_concentration = ion_concentration
 
     @property
@@ -130,16 +130,13 @@ class SolventComponent(Component):
     def from_dict(cls, d):
         """Deserialize from dict representation"""
         ion_conc = d['ion_concentration']
-        if ion_conc:
-            d['ion_concentration'] = unit.Quantity.from_tuple(ion_conc)
+        d['ion_concentration'] = unit.parse_expression(ion_conc)
 
         return cls(**d)
 
     def to_dict(self):
         """For serialization"""
-        ion_conc = self.ion_concentration
-        if ion_conc:
-            ion_conc = ion_conc.to_tuple()
+        ion_conc = str(self.ion_concentration)
 
         return {'smiles': self.smiles, 'positive_ion': self.positive_ion,
                 'negative_ion': self.negative_ion,

--- a/gufe/components/solventcomponent.py
+++ b/gufe/components/solventcomponent.py
@@ -71,7 +71,7 @@ class SolventComponent(Component):
         self._neutralize = neutralize
 
         if (not isinstance(ion_concentration, unit.Quantity)
-           or not ion_concentration.is_compatible_with(unit.molar)):
+            or not ion_concentration.is_compatible_with(unit.molar)):
             raise ValueError(f"ion_concentration must be given in units of"
                              f" concentration, got: {ion_concentration}")
         if ion_concentration.m < 0:

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -10,7 +10,7 @@ def test_defaults():
     assert s.smiles == 'O'
     assert s.positive_ion == "Na+"
     assert s.negative_ion == "Cl-"
-    assert s.ion_concentration is None
+    assert s.ion_concentration == 0.0 * unit.molar
 
 
 @pytest.mark.parametrize('pos, neg', [
@@ -26,6 +26,7 @@ def test_hash(pos, neg):
     assert s2.positive_ion == 'Na+'
     assert s2.negative_ion == 'Cl-'
 
+
 def test_neq():
     s1 = SolventComponent(positive_ion='Na', negative_ion='Cl')
     s2 = SolventComponent(positive_ion='K', negative_ion='Cl')
@@ -40,10 +41,10 @@ def test_to_dict():
                            'positive_ion': 'Na+',
                            'negative_ion': 'Cl-',
                            'neutralize': True,
-                           'ion_concentration': None}
+                           'ion_concentration': '0.0 molar'}
 
 
-@pytest.mark.parametrize('conc', [None, 1.75 * unit.molar])
+@pytest.mark.parametrize('conc', [0.0 * unit.molar, 1.75 * unit.molar])
 def test_from_dict(conc):
     s1 = SolventComponent(positive_ion='Na', negative_ion='Cl',
                           ion_concentration=conc,
@@ -61,7 +62,8 @@ def test_conc():
 
 @pytest.mark.parametrize('conc,',
                          [1.22,  # no units, 1.22 what?
-                          1.5 * unit.kg])  # probably a tad much salt
+                          1.5 * unit.kg,  # probably a tad much salt
+                          -0.1 * unit.molar])  # negative conc
 def test_bad_conc(conc):
     with pytest.raises(ValueError):
         _ = SolventComponent(positive_ion='Na', negative_ion='Cl',


### PR DESCRIPTION
I think @dwhswenson asked about this and we forgot to implement, it seems neater to always have this exist rather than `None` sometimes