### PR TITLE
Raise NotImplementedError in abstract classmethods

### DIFF
--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -138,7 +138,7 @@ class Protocol(GufeTokenizable):
         reasonable defaults for this `Protocol` subclass.
 
         """
-        ...
+        raise NotImplementedError()
 
     @classmethod
     def default_settings(cls) -> "ProtocolSettings":      # type: ignore

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -117,7 +117,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         serialization into e.g. JSON difficult.
 
         """
-        ...
+        raise NotImplementedError()
 
     @classmethod
     @abc.abstractmethod
@@ -126,7 +126,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         `GufeTokenizable` subclass and generate an instance from it.
 
         """
-        ...
+        raise NotImplementedError()
 
     def to_dict(self, include_defaults=True) -> dict:
         """Generate full dict representation, with all referenced


### PR DESCRIPTION
As @RiesBen noted in https://github.com/OpenFreeEnergy/gufe/pull/45#discussion_r974148678, leaving the body of an abstract method as `...` can return `None`. I'm not too worried about this for instance methods, where the `abc.abstractmethod` decorator prevents us from instantiating if unimplemented (although you can still do `AbstractClass.abstract_method(self=explicit_object, ...)`).

However, classmethods are typically called without instance, as `ClassName.class_method(...)`. The `abc.abstractmethod` decorator does nothing to protect us there.

This PR ensures that all abstract class methods raise `NotImplementedError`. (I went ahead and changed the abstract `_to_dict` as well, so that it matches `_from_dict`.)