### PR TITLE
Use the gufe key for DAG name, not hash

### DIFF
--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -137,7 +137,7 @@ class Transformation(GufeTokenizable):
             stateA=self.stateA,
             stateB=self.stateB,
             mapping=self.mapping,
-            name=str(self.__hash__()),
+            name=str(self.key),
         )
 
     def gather(


### PR DESCRIPTION
I think this is what was actually desired, and using `hash` was just an older idea that didn't get caught in review.

(1-line change)