### PR TITLE
Add custom_json from OpenPathSampling / SimStore

### DIFF
--- a/gufe/custom_json.py
+++ b/gufe/custom_json.py
@@ -1,0 +1,165 @@
+# This file was originally part of OpenPathSampling/SimStore.
+
+import json
+import functools
+import inspect
+from collections import namedtuple, defaultdict
+
+
+class JSONSerializerDeserializer(object):
+    """
+    Tools to serialize and deserialize objects as JSON.
+
+    This wrapper object is necessary so that we can register new codecs
+    after the original initialization.
+
+    Attributes
+    ----------
+    encoder:
+        subclass of ``JSONEncoder``; use as ``json.dumps(obj, cls=encoder)``
+    decoder:
+        subclass of ``JSONDecoder``; use as ``json.loads(string,
+        cls=decoder)``
+
+    Parameters
+    ----------
+    codecs : list of :class:`.JSONCodec`s
+        codecs supported
+    """
+    def __init__(self, codecs, named_codecs=None):
+        self.named_codecs = {} if named_codecs is None else named_codecs
+        self.codecs = []
+        for codec in codecs:
+            self.add_codec(codec)
+
+        self.encoder, self.decoder = self._set_serialization()
+
+    def _set_serialization(self):
+        encoder, decoder = custom_json_factory(self.codecs)
+        self._serializer = functools.partial(json.dumps, cls=encoder)
+        self._deserializer = functools.partial(json.loads, cls=decoder)
+        return encoder, decoder
+
+    def add_codec(self, codec):
+        """Add a new codec to the supported codecs
+
+        Parameters
+        ----------
+        codec : :class:`.JSONCodec`
+            codec to add
+        """
+        if codec in self.codecs:
+            return
+
+        if codec is not None:
+            self.codecs.append(codec)
+
+        self.encoder, self.decoder = self._set_serialization()
+
+    def replace_named_codec(self, codec_name, codec):
+        self.named_codecs[codec_name] = codec
+        self.add_codec(None)
+
+    def serializer(self, obj):
+        """Callable that dumps to JSON"""
+        return self._serializer(obj)
+
+    def deserializer(self, string):
+        """Callable to loads JSON"""
+        return self._deserializer(string)
+
+
+def custom_json_factory(coding_methods):
+    """Create JSONEncoder/JSONDecoder for special types
+    """
+    class CustomJSONEncoder(json.JSONEncoder):
+        def default(self, obj):
+            for coding_method in coding_methods:
+                result = coding_method.default(obj)
+                if result is not obj:
+                    return result
+            return json.JSONEncoder.default(self, obj)
+
+    class CustomJSONDecoder(json.JSONDecoder):
+        def __init__(self, *args, **kwargs):
+            super(CustomJSONDecoder, self).__init__(
+                object_hook=self.object_hook, *args, **kwargs
+            )
+
+        def object_hook(self, dct):
+            for coding_method in coding_methods:
+                result = coding_method.object_hook(dct)
+                if result is not dct:
+                    return result
+            return dct
+
+    return (CustomJSONEncoder, CustomJSONDecoder)
+
+
+class JSONCodec(object):
+    """Custom JSON encoding and decoding for non-default types.
+
+    Parameters
+    ----------
+    cls : class
+        Class for this codec. Assumes that all subclasses should be treated
+        the same way. Can be ``None`` if ``is_my_obj`` and ``is_my_dict``
+        are given.
+    to_dict : Callable
+        method that converts the object to a dictionary
+    from_dict : Callable
+        method that restores the object based on the dictionary made by
+        to_dict
+    is_my_obj : Optional[Callable]
+        Method to determine whether the input object should be treated by
+        this encoder. Default behavior is to use ``isinstance(cls)``, and to
+        create a dict that also includes the class name and the module of
+        the object.
+    is_my_dict : Optional[Callable]
+        Method to determine whether the input dictionary should be treated
+        by this decoder. Default behavior assumes usage of the default
+        ``is_my_obj``.
+    """
+    def __init__(self, cls, to_dict, from_dict, is_my_obj=None,
+                 is_my_dict=None):
+        if is_my_obj is None:
+            is_my_obj = self._is_my_obj
+
+        if is_my_dict is None:
+            is_my_dict = self._is_my_dict
+
+        self.cls = cls
+        self.to_dict = to_dict
+        self.from_dict = from_dict
+        self.is_my_obj = is_my_obj
+        self.is_my_dict = is_my_dict
+
+    def _is_my_dict(self, dct):
+        expected = ['__class__', '__module__', ':is_custom:']
+        is_custom = all(exp in dct for exp in expected)
+        if is_custom:
+            return (dct['__class__'] == self.cls.__name__
+                    and dct['__module__'] == self.cls.__module__)
+
+    def _is_my_obj(self, obj):
+        return isinstance(obj, self.cls)
+
+    def default(self, obj):
+        if self.is_my_obj(obj):
+            dct = {}
+            if self.cls:
+                dct.update({
+                    '__class__': self.cls.__name__,
+                    '__module__': self.cls.__module__,
+                    ':is_custom:': True,
+                })
+            # we let the object override __class__ and __module__ if needed
+            dct.update(self.to_dict(obj))
+            return dct
+        return obj
+
+    def object_hook(self, dct):
+        if self.is_my_dict(dct):
+            obj = self.from_dict(dct)
+            return obj
+        return dct

--- a/gufe/tests/test_custom_json.py
+++ b/gufe/tests/test_custom_json.py
@@ -1,0 +1,117 @@
+from gufe.custom_json import (
+    JSONSerializerDeserializer, custom_json_factory, JSONCodec
+)
+import json
+import pytest
+
+import numpy as np
+from numpy import testing as npt
+
+bytes_codec = JSONCodec(
+    cls=bytes,
+    to_dict=lambda obj: {'latin-1': obj.decode('latin-1')},
+    from_dict=lambda dct: dct['latin-1'].encode('latin-1'),
+)
+
+numpy_codec = JSONCodec(
+    cls=np.ndarray,
+    to_dict=lambda obj: {
+        'dtype': str(obj.dtype),
+        'shape': list(obj.shape),
+        'bytes': obj.tobytes()
+    },
+    from_dict=lambda dct: np.frombuffer(
+        dct['bytes'], dtype=np.dtype(dct['dtype'])
+    ).reshape(dct['shape'])
+)
+
+
+class TestJSONSerializerDeserializer(object):
+    def test_add_codec(self):
+        # without bytes codec, can't serialize numpy
+        serialization = JSONSerializerDeserializer([numpy_codec])
+        obj = np.array([[1.0, 0.0], [2.0, 3.2]])
+        with pytest.raises(TypeError):
+            serialization.serializer(obj)
+        # add the codec and it will work
+        serialization.add_codec(bytes_codec)
+        serialized = serialization.serializer(obj)
+        assert len(serialization.codecs) == 2
+        reconstructed = serialization.deserializer(serialized)
+        npt.assert_equal(obj, reconstructed)
+
+
+class CustomJSONCodingTest(object):
+    """Base class for testing codecs.
+
+    In ``setup()``, user must define the following:
+
+    * ``self.codec``: The codec to run
+    * ``self.objs``: A list of objects to serialize
+    * ``self.dcts``: A list of expected serilized forms of each object in
+      ``self.objs``
+    """
+    def test_default(self):
+        for (obj, dct) in zip(self.objs, self.dcts):
+            assert self.codec.default(obj) == dct
+
+    def test_object_hook(self):
+        for (obj, dct) in zip(self.objs, self.dcts):
+            assert self.codec.object_hook(dct) == obj
+
+    def _test_round_trip(self, encoder, decoder):
+        for (obj, dct) in zip(self.objs, self.dcts):
+            json_str = json.dumps(obj, cls=encoder)
+            reconstructed = json.loads(json_str, cls=decoder)
+            assert reconstructed == obj
+            json_str_2 = json.dumps(obj, cls=encoder)
+            assert json_str == json_str_2
+
+    def test_round_trip(self):
+        encoder, decoder = custom_json_factory([self.codec])
+        self._test_round_trip(encoder, decoder)
+
+    def test_not_mine(self):
+        # test that the default behavior is obeyed
+        obj = {'test': 5}
+        json_str = '{"test": 5}'
+        encoder, decoder = custom_json_factory([self.codec])
+        assert json.dumps(obj, cls=encoder) == json_str
+        assert json.loads(json_str, cls=decoder) == obj
+
+
+
+class TestNumpyCoding(CustomJSONCodingTest):
+    def setup(self):
+        self.codec = numpy_codec
+        self.objs = [np.array([[1.0, 0.0], [2.0, 3.2]]),
+                     np.array([1, 0])]
+        shapes = [[2, 2], [2,]]
+        dtypes = [str(arr.dtype) for arr in self.objs]  # may change by system?
+        byte_reps = [arr.tobytes() for arr in self.objs]
+        self.dcts = [
+            {
+                ':is_custom:': True,
+                '__class__': 'ndarray',
+                '__module__': 'numpy',
+                 'shape': shape,
+                 'dtype': dtype,
+                 'bytes': byte_rep
+            }
+            for shape, dtype, byte_rep in zip(shapes, dtypes, byte_reps)
+        ]
+
+    def test_object_hook(self):
+        # to get custom equality testing for numpy
+        for (obj, dct) in zip(self.objs, self.dcts):
+            reconstructed = self.codec.object_hook(dct)
+            npt.assert_array_equal(reconstructed, obj)
+
+    def test_round_trip(self):
+        encoder, decoder = custom_json_factory([self.codec, bytes_codec])
+        for (obj, dct) in zip(self.objs, self.dcts):
+            json_str = json.dumps(obj, cls=encoder)
+            reconstructed = json.loads(json_str, cls=decoder)
+            npt.assert_array_equal(reconstructed, obj)
+            json_str_2 = json.dumps(obj, cls=encoder)
+            assert json_str == json_str_2


### PR DESCRIPTION
This adds in the custom JSON setup I originally developed for SimStore. Quick overview:

#### What's wrong with Python's JSON

`json.dumps` and `json.loads` both provide a couple ways to extend to arbitrary types: you can either provide a custom function (`default` for dump, `object_hook` for load) or you can provide a custom class (`cls` for both). That class will subclass `json.JSONEncoder` or `json.JSONDecoder` and implement either `default` or `object_hook`.

The problem is that these approaches are not composable. So if you have an encoder for OpenFF units and another encoder for pydantic models, you need to write yet a third encoder to combine the two.

#### What SimStore does

In SimStore, I created a `JSONCodec` class that combines the functionality of the `JSONEncoder` and `JSONDecoder`. Then I created a `JSONSerializationDeserialization` class that takes multiple `JSONCodec`s on initialization and dynamically generates a `json.JSONEncoder` and `json.JSONDecoder` from them. You then have a global instance of `JSONSerializationDeserialization` that you can use. Furthermore, this allows addition of codecs at runtime.

This could be used as `json.dumps(obj, cls=GLOBAL_SERIALIZER.encoder)`, or you can directory use the `serializer` / `deserializer` methods, which return the callable (that has to do with SimStore's model; we'll probably just use the `encoder`/`decoder` attributes.

The API for `JSONCodec` is pretty simple. In general, you need to define a `to_dict` function for the object and a `from_dict` function. The codec is an instance of `JSONCodec` that takes the `to_dict` and `from_dict` as parameters. You also need to provide a way to recognize 

Advantages:

* allows arbitrary composition of individual codecs
* even allows addition of codecs at runtime (e.g., from external packages)
* code is already in place and tested

#### Practical usage

To add a codec for another type, in principle you need need 4 things:

* a way of identifying whether the in-memory object should be serialized by this codec (`is_my_obj`); this defaults to an `isinstance` check on the provided class `cls`
* a way of converting that into a JSON-ready format; this is the user-provided `to_dict` method
* a way of identifying whether a given dict should be deserialized by this codec (`is_my_dict`), which should be the default method unless a user
* a way of converting the dictionary to the in-memory object; this is the user-provided `from_dict` method

In practice, you typically only need to provide `to_dict` and `from_dict` (and the class so we can do an `isinstance` check). However, if you want to get into the weeds, you can customize `is_my_obj` and `is_my_dict`.

You can see examples of this in the tests, where I create a custom codec for `numpy.ndarray`. Since the `to_dict` of that actually returns `bytes`, I also create a custom codec for `bytes`.


Resolves #64.