### PR TITLE
Add test for roundtrip with cleared registry

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -68,16 +68,7 @@ class ExplicitMoleculeComponent(Component):
             )
 
         self._rdkit = rdkit
-        self._hash = self._hashmol(name=name)
-
-    def __hash__(self):
-        return hash(self._hash)
-
-    def __eq__(self, other):
-        return hash(self) == hash(other)
-
-    def _hashmol(self, name):
-        return hashmol(self._rdkit, name=name)
+        self._hash = hashmol(self._rdkit, name=name)
 
     def _defaults(self):
         return super()._defaults()

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -4,7 +4,6 @@ from rdkit import Chem
 
 from .component import Component
 from .. import __version__
-from ..molhashing import hashmol
 
 # typing
 from ..custom_typing import RDKitMol
@@ -48,9 +47,6 @@ class ExplicitMoleculeComponent(Component):
     This provides basic serialization and conversion to different
     representations. Specific file formats, such as SDF for small molecules
     or PDB for proteins, should be implemented in subclasses.
-
-    We default to use SMILES as the basis of the hash, but this can be
-    overridden using the `_hashmol` method.
     """
 
     def __init__(self, rdkit: RDKitMol, name: str = ""):
@@ -68,7 +64,8 @@ class ExplicitMoleculeComponent(Component):
             )
 
         self._rdkit = rdkit
-        self._hash = hashmol(self._rdkit, name=name)
+        self._smiles = None
+        self._name = name
 
     def _defaults(self):
         return super()._defaults()
@@ -76,11 +73,14 @@ class ExplicitMoleculeComponent(Component):
     # Props
     @property
     def name(self) -> str:
-        return self._hash.name
+        return self._name
 
     @property
     def smiles(self) -> str:
-        return self._hash.smiles
+        if self._smiles is None:
+            self._smiles = Chem.MolToSmiles(self._rdkit)
+
+        return self._smiles
 
     @property
     def total_charge(self):

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -1,6 +1,7 @@
 import json
 import warnings
 from rdkit import Chem
+from typing import Optional
 
 from .component import Component
 from .. import __version__
@@ -64,7 +65,7 @@ class ExplicitMoleculeComponent(Component):
             )
 
         self._rdkit = rdkit
-        self._smiles = None
+        self._smiles: Optional[str] = None
         self._name = name
 
     def _defaults(self):
@@ -78,7 +79,7 @@ class ExplicitMoleculeComponent(Component):
     @property
     def smiles(self) -> str:
         if self._smiles is None:
-            self._smiles = Chem.MolToSmiles(self._rdkit)
+            self._smiles = Chem.MolToSmiles(Chem.RemoveHs(self._rdkit))
 
         return self._smiles
 

--- a/gufe/molhashing.py
+++ b/gufe/molhashing.py
@@ -5,17 +5,6 @@ import numpy as np
 from rdkit import Chem
 from typing import NamedTuple
 
-
-class MoleculeHash(NamedTuple):
-    smiles: str
-    name: str
-
-
-def hashmol(mol, name=""):
-    # MolToSMILES are canonical by default
-    return MoleculeHash(Chem.MolToSmiles(mol), name)
-
-
 def serialize_numpy(arr) -> str:
     npbytes = io.BytesIO()
     np.save(npbytes, arr, allow_pickle=False)

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -21,6 +21,7 @@ import gufe
 import json
 from rdkit import Chem
 from rdkit.Chem import AllChem
+from gufe.tokenization import TOKENIZABLE_REGISTRY
 
 from .test_tokenization import GufeTokenizableTestsMixin
 
@@ -179,6 +180,15 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin):
         mol = SmallMoleculeComponent.from_rdkit(rdkit, "ethane")
         assert mol == named_ethane
         assert mol.to_rdkit() is not rdkit
+
+    def test_serialization_cycle_smiles(self, named_ethane):
+        # check a regression against the smiles changing on serialization
+        dct = named_ethane.to_dict()
+        TOKENIZABLE_REGISTRY.clear()
+        copy = SmallMoleculeComponent.from_dict(dct)
+        assert named_ethane == copy
+        assert named_ethane is not copy
+        assert named_ethane.smiles == copy.smiles
 
 
 class TestSmallMoleculeComponentConversion:

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -93,6 +93,15 @@ class GufeTokenizableTestsMixin(abc.ABC):
         # include `np.nan`s
         #assert ser == reser
 
+    def test_to_dict_roundtrip_clear_registry(self, instance):
+        ser = instance.to_dict()
+        TOKENIZABLE_REGISTRY.clear()
+        deser = self.cls.from_dict(ser)
+        reser = deser.to_dict()
+
+        assert instance == deser
+        assert instance is not deser
+
     def test_to_keyed_dict_roundtrip(self, instance):
         ser = instance.to_keyed_dict()
         deser = self.cls.from_keyed_dict(ser)

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -362,12 +362,15 @@ def key_encode_dependencies(obj: GufeTokenizable) -> Dict:
 # decode options
 def from_dict(dct) -> GufeTokenizable:
     obj = _from_dict(dct)
-    try:
-        thing = TOKENIZABLE_REGISTRY[obj.key]
-    except KeyError:
-        thing = None
+    # When __new__ is called to create ``obj``, it should be added to the
+    # TOKENIZABLE_REGISTRY. However, there seems to be some case (race
+    # condition?) where this doesn't happen, leading to a KeyError inside
+    # the dictionary if we use []. (When you drop into PDB and run the same
+    # line that gave the error, you get the object back.) With ``get``,
+    # ``thing`` becomes None, which is also what it would be if the weakref
+    # was to a deleted object.
+    thing = TOKENIZABLE_REGISTRY.get(obj.key)
 
-    # weakref will return None if the object was deleted
     if thing is None:
         return obj
     else:

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -362,7 +362,10 @@ def key_encode_dependencies(obj: GufeTokenizable) -> Dict:
 # decode options
 def from_dict(dct) -> GufeTokenizable:
     obj = _from_dict(dct)
-    thing = TOKENIZABLE_REGISTRY[obj.key]
+    try:
+        thing = TOKENIZABLE_REGISTRY[obj.key]
+    except KeyError:
+        thing = None
 
     # weakref will return None if the object was deleted
     if thing is None:


### PR DESCRIPTION
Main goal here is to add a test to `GufeTokenizableTestsMixin` that will automatically test that the full `to_dict`/`from_dict` cycle works if the `TOKENIZABLE_REGISTRY` has been cleared, to mock deserializing in a different process from the serialization.

This led to some weirdness:

* I got the same problem with `WeakValueDictionary` that I mentioned this morning; where I get a `KeyError`, but if you drop into the pdb on error, the key is in the dict. I fixed this by putting a `try`/`except` around that.
* There is a genuine error in serialization of `SmallMoleculeComponent`. It's because we serialize with explicit hydrogens, but don't force explicit hydrogens when we take in an rdkit molecule. So the original ethane has smiles `CC` and the deserialized one has `[H]C([H])([H])C([H])([H])[H]` (@richardjgowers is going to love this one!). I think the options are either:
  * `addHydrogens` on taking in the molecule
  * `removeHydrogens` before calculating the SMILES string for hashing

Tasks:

- [x] Draft test
- [x] Fix problem with WeakValueDictionary
- [x] Fix problem with `SmallMoleculeComponent`