### PR TITLE
Add __init__.py to vendor/

### DIFF
--- a/gufe/components/proteincomponent.py
+++ b/gufe/components/proteincomponent.py
@@ -110,7 +110,8 @@ class ProteinComponent(ExplicitMoleculeComponent):
         )
 
     @classmethod
-    def _from_openmmPDBFile(cls, openmm_PDBFile: PDBFile, name: str = ""):
+    def _from_openmmPDBFile(cls, openmm_PDBFile: Union[PDBFile, PDBxFile],
+                            name: str = ""):
         """
         This Function deserializes openmmPDBFile
 


### PR DESCRIPTION
Getting errors on OpenFE PRs with `ModuleNotFoundError: No module named 'gufe.vendor'` -- hoping this is all that is needed to fix.