### PR TITLE
[DOCS] Serialization

### DIFF
--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -20,8 +20,8 @@ Directed acylic graphs of work
 
 .. autoclass:: gufe.protocols.ProtocolDAGResult
 	       :members:
-		  
-		  
+
+
 Individual units of work
 ========================
 		  

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -8,4 +8,5 @@ Guide to GUFE
 
    guide/components_and_systems
    guide/protocols
+   guide/serialization
    guide/storage

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -182,7 +182,7 @@ the same object in memory referenced by multiple objects (e.g., an identical
 save multiple copies of its JSON representation.
 
 On reloading, tools that use the recommended ``from_dict`` method will undo
-do this duplication; see :ref:`gufe_memory_deduplication` for details.
+do this duplication; see :ref:`gufe-memory-deduplication` for details.
 
 .. Using JSON codecs outside of JSON
 .. ---------------------------------
@@ -253,7 +253,7 @@ deduplicated on storage to disk because we store by reference to the gufe
 key. Additionally, objects are deduplicated in memory because we keep a
 registry of all instantiated GufeTokenizables.
 
-.. _gufe_memory-deduplication:
+.. _gufe-memory-deduplication:
 
 Deduplication in memory
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -18,7 +18,40 @@ In practice: What a developer needs to do
 For most use cases, an object can be made serializable by gufe if it (1)
 inherits from :class:`.GufeTokenizable` and (2) implements several abstract
 private methods related to serialization: ``_to_dict``, ``_from_dict``, and
-``_defaults``.
+``_defaults``:
+
+* ``_to_dict`` returns a dictionary mapping string names for each attribute
+  to preserve to a serializable representation of that attribute. A
+  representation is considered "serializable" if it is (1) a
+  :class:`.GufeTokenizable`, (2) a primitive type that can be handled by
+  Python's built-in JSON, or (3) a type for which a custom
+  :class:`.JSONCodec` has been registered (see :ref:`Supporting custom types
+  in serialization`).
+* ``_from_dict`` is a ``classmethod`` that takes the dictionary returned by
+  ``_to_dict`` and reconstructs the object.
+* ``_defaults`` returns whatever ``_to_dict`` would return for any default
+  values; i.e., it should be a dictionary ...
+
+
+As a very simple example, consider the following complete implementation:
+
+.. code::
+
+    class Foo(GufeTokenizable):
+        def __init__(self, bar, baz=None):
+            self.bar = bar
+            self.baz = baz
+
+        def _to_dict(self):
+            return {'bar': self.bar, 'baz': self.baz}
+
+        @classmethod
+        def _from_dict(cls, dct):
+            return cls(**dct)
+
+        def _defaults(self):
+            return {'baz': None}
+
 
 Supporting custom types in serialization
 ----------------------------------------
@@ -29,7 +62,8 @@ in your GUFE object that come from another library, and are not GUFE
 tokenizables.
 
 When this happens, you will need to create and register a custom JSON
-codec. 
+codec. To do this, at a minimum you need to define a ``to_dict`` and
+``from_dict`` method for your type. Additionally, the 
 
 Dumping arbitrary objects to JSON
 ---------------------------------
@@ -56,6 +90,11 @@ Similarly, you can reload the object with:
     with open(filename, mode='r') as f:
         obj = json.load(f, cls=JSON_HANDLER.decoder)
 
+Using JSON codecs outside of JSON
+---------------------------------
+
+In a custom recursive storage scheme, 
+
 When your object has recursive references
 -----------------------------------------
 
@@ -64,7 +103,8 @@ For example, you may have objects ``parent`` and ``child``, where
 ``parent.children`` includes ``child`` and ``child.parent`` is ``parent``.
 This means that the object dependency graph is not a directed acyclic graph.
 The best solution here is to avoid this design pattern whenever possible.
-However, if it is unavoidable, 
+However, if it is unavoidable, the way to do this is to set the
+``child.parent`` attribute as part of the ``parent._from_dict`` method.
 
 Understanding the theory: The GUFE key
 --------------------------------------
@@ -73,12 +113,13 @@ One of the important concepts is that every GUFE object has a unique
 identifier, which we call its ``key``. The ``key`` is a string, typically
 in the format ``{CLASS_NAME}-{HEXADECIMAL_LABEL}``. The hexadecimal label is
 generated based on the contents of the class -- in particular, it is based
-on the non-default contents of the ``to_dict`` method. 
+on contents of the ``_to_dict`` dictionary, filtered to remove anything that
+matches the ``_defaults`` dictionary.
 
+This gives the GUFE key a number of important properties:
 
-Things storage systems may do
------------------------------
+* GUFE keys can be used for store-by-reference: When one GufeTokenizable
+  contains another, the inner object can store 
 
-Details on the implementation of storage systems is largely left to
-individual projects that build on GUFE. However, the existence of the GUFE
-key enables a number of powerful capabilities in storage.
+Deduplication of GufeTokenizables
+---------------------------------

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -90,7 +90,32 @@ tokenizables.
 
 When this happens, you will need to create and register a custom JSON
 codec. To do this, at a minimum you need to define a ``to_dict`` and
-``from_dict`` method for your type. Additionally, the  ???
+``from_dict`` function for your type. You can then give the class of your
+type and those functions to a :class:`.JSONCodec`.  As an example, consider
+the code for our codec for ``pathlib.Path`` objects:
+
+.. code::
+
+    PATH_CODEC = JSONCodec(
+        cls=pathlib.Path,
+        to_dict=lambda p: {'path': str(p)},
+        from_dict=lambda dct: pathlib.Path(dct['path'])
+    )
+
+Here the ``to_dict`` and ``from_dict`` are lambdas. The ideas of these are
+the same as the ``GufeTokenizable._to_dict`` and
+``GufeTokenizable._from_dict`` described above.
+
+In this default setup, the codec recognizes your object type by doing an
+``isinstance`` check on the ``cls`` you gave it. It updates the dictionary
+that comes from your ``to_dict`` with the class and module of the object,
+as well as a key to mark this dictionary as coming from this codec. The
+key-value pairs that it adds make it so that the codec can recognize the
+dictionary when it is deserializes (decodes) the data.
+
+Details of how the object is recognized for encoding or how the dictionary
+is recognized for decoding can be changed by passing functions to the
+``is_my_obj`` or ``is_my_dict`` parameters of :class:`.JSONCodec`.
 
 Dumping arbitrary objects to JSON
 ---------------------------------

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -25,13 +25,17 @@ private methods related to serialization: ``_to_dict``, ``_from_dict``, and
   representation is considered "serializable" if it is (1) a
   :class:`.GufeTokenizable`, (2) a primitive type that can be handled by
   Python's built-in JSON, or (3) a type for which a custom
-  :class:`.JSONCodec` has been registered (see :ref:`Supporting custom types
-  in serialization`).
+  :class:`.JSONCodec` has been registered (see :ref:`customjson`).
 * ``_from_dict`` is a ``classmethod`` that takes the dictionary returned by
   ``_to_dict`` and reconstructs the object.
 * ``_defaults`` returns whatever ``_to_dict`` would return for any default
-  values; i.e., it should be a dictionary ...
-
+  values; i.e., it should be a dictionary where the keys are the the keys of
+  the ``_to_dict`` dictionary that have default values, and the values are
+  the associated defaults. Importantly, this may differ from the default
+  value given at initialization -- for example, it is common practice to use
+  ``None`` as a stand-in for a mutable container (e.g., an empty list). In
+  that case, the value given by ``_defaults`` should be the container, not
+  ``None``, since that is what will be in the ``_to_dict``.
 
 As a very simple example, consider the following complete implementation:
 
@@ -40,6 +44,8 @@ As a very simple example, consider the following complete implementation:
     class Foo(GufeTokenizable):
         def __init__(self, bar, baz=None):
             self.bar = bar
+            if baz is None:
+                baz = []
             self.baz = baz
 
         def _to_dict(self):
@@ -50,8 +56,29 @@ As a very simple example, consider the following complete implementation:
             return cls(**dct)
 
         def _defaults(self):
-            return {'baz': None}
+            return {'baz': []}
 
+GufeTokenizables must be functionally immutable
+-----------------------------------------------
+
+One important restriction on :class:`.GufeTokenizable` subclasses is that
+they must be functionally immutable. That is, they must have no mutable
+attributes that change their functionality. In most cases, this means that
+the object must be strictly immutable.
+
+As an example of a mutable attribute that does not change functionality,
+consider a flag to turn on or off usage of a cache of input-output pairs for
+some deterministic method. If the cache is turned on, you first try to
+return the value from it, and only perform the calculation if the inputs
+don't have a cached output associated. In this case, the flag is mutable,
+but this has no effect on the results.  Indeed, the cache itself may be
+implemented as a mutable attribute of the object, but again, this would not
+change the results that are returned.
+
+On the other hand, a flag that changes code path in a way that might
+change the results of any operation would not be allowed.
+
+.. _customjson:
 
 Supporting custom types in serialization
 ----------------------------------------
@@ -63,16 +90,14 @@ tokenizables.
 
 When this happens, you will need to create and register a custom JSON
 codec. To do this, at a minimum you need to define a ``to_dict`` and
-``from_dict`` method for your type. Additionally, the 
+``from_dict`` method for your type. Additionally, the  ???
 
 Dumping arbitrary objects to JSON
 ---------------------------------
 
-Advanced storage systems are space-efficient by only storing each object
-once. However, any :class:`.GufeTokenizable` can be dumped to a JSON file
-using the custom JSON handlers. Given a :class:`.GufeTokenizable` called
-``obj`` and a path-like called ``filename``, you can dump to JSON with this
-recipe:
+Any :class:`.GufeTokenizable` can be dumped to a JSON file using the custom
+JSON handlers. Given a :class:`.GufeTokenizable` called ``obj`` and a
+path-like called ``filename``, you can dump to JSON with this recipe:
 
 .. code::
 
@@ -90,10 +115,19 @@ Similarly, you can reload the object with:
     with open(filename, mode='r') as f:
         obj = json.load(f, cls=JSON_HANDLER.decoder)
 
-Using JSON codecs outside of JSON
----------------------------------
+Note that these objects are not space-efficient: that is, if you have
+the same object in memory stored at multiple locations (e.g., an identical
+``SolventComponent`` in more than one ``ChemicalSystem``), then you will
+save multiple copies of its JSON representation.
 
-In a custom recursive storage scheme, 
+.. Using JSON codecs outside of JSON
+.. ---------------------------------
+
+.. In a custom recursive storage scheme, 
+
+.. TODO: DWHS wants to write something here that describes how to use the
+   codecs in your own non-JSON storage scheme. But this is complicated
+   enough that it will take significant time
 
 When your object has recursive references
 -----------------------------------------
@@ -103,23 +137,56 @@ For example, you may have objects ``parent`` and ``child``, where
 ``parent.children`` includes ``child`` and ``child.parent`` is ``parent``.
 This means that the object dependency graph is not a directed acyclic graph.
 The best solution here is to avoid this design pattern whenever possible.
-However, if it is unavoidable, the way to do this is to set the
-``child.parent`` attribute as part of the ``parent._from_dict`` method.
+Importantly, the ``child`` object in this case cannot be immutable, unless
+it is only created as a part of the creation of ``parent``.
+
+However, this could be made functionally immutable by (1) requiring that a
+valid ``child`` set its ``parent`` attribute exactly once; (2) not storing
+the ``child.parent`` attribute, and instead ensuring it gets set by the
+``parent`` (e.g., in ``__init__``). Note that this also assumes that all
+``children`` are provided to ``parent`` on initialization, otherwise
+``parent`` is also mutable.
+
+Another approach here would be to make it so that ``child`` was not a
+:class:`.GufeTokenizable`, and instead explicitly handle its serialization
+in a more complicated ``parent._to_dict`` method, with similarly more
+complicated ``parent._from_dict``. This approach is particularly useful if
+the ``child`` object isn't too complicated, and if the ``child`` is unlikely
+to be reused outside the context of the ``parent``.
 
 Understanding the theory: The GUFE key
 --------------------------------------
 
 One of the important concepts is that every GUFE object has a unique
 identifier, which we call its ``key``. The ``key`` is a string, typically
-in the format ``{CLASS_NAME}-{HEXADECIMAL_LABEL}``. The hexadecimal label is
-generated based on the contents of the class -- in particular, it is based
-on contents of the ``_to_dict`` dictionary, filtered to remove anything that
-matches the ``_defaults`` dictionary.
+in the format ``{CLASS_NAME}-{HEXADECIMAL_LABEL}``. For most objects, the
+hexadecimal label is generated based on the contents of the class -- in
+particular, it is based on contents of the ``_to_dict`` dictionary, filtered
+to remove anything that matches the ``_defaults`` dictionary.
 
 This gives the GUFE key a number of important properties:
 
-* GUFE keys can be used for store-by-reference: When one GufeTokenizable
-  contains another, the inner object can store 
+* Because the key is based on a cryptographic hash, it is extremely unlikely
+  that two objects that are functionally different will have the same key.
+* Because the key is created deterministically, it is preserved across
+  different creation times, including across different hardware, across
+  different Python sessions, and even within the same Python session.
+* Because the key is based on the non-default attributes, it is preserved
+  across minor versions of the code.
+
+These properties make the GUFE key a stable identifier for the object, which
+means that they can be used for store-by-reference.  When one
+GufeTokenizable contains another, the outer object can store the inner
+object's key. This allows us to reduce disk usage by only storing one copy
+of each object (deduplication).
 
 Deduplication of GufeTokenizables
 ---------------------------------
+
+There are two types of deduplication of GufeTokenizables. Objects are
+deduplicated on storage to disk because we store by reference to the gufe
+key. Additionally, objects are deduplicated in memory because we keep a
+registry of all instantiated GufeTokenizables.
+
+.. TODO: explain weird sides of that, like the fact that you get the same
+   object back when you create another one

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -1,0 +1,84 @@
+Serializing GUFE objects
+========================
+
+When you create objects the follow the GUFE APIs, you will want them to be
+serializable; that is, you'll want to be able to store everything to disk.
+In this section, we'll discuss how GUFE handles serialization, and what a
+developer needs to do to serialize an object.
+
+From a user perspective, this information is mainly relevant for
+understanding what you can expect from storage systems built for GUFE
+objects. From a developer perspective, this will tell you what you need to
+do to be compatible with (and get the most from) the GUFE serialization
+mechanisms.
+
+In practice: What a developer needs to do
+-----------------------------------------
+
+For most use cases, an object can be made serializable by gufe if it (1)
+inherits from :class:`.GufeTokenizable` and (2) implements several abstract
+private methods related to serialization: ``_to_dict``, ``_from_dict``, and
+``_defaults``.
+
+Supporting custom types in serialization
+----------------------------------------
+
+Occasionally, you may need to add support for a custom type that is not
+already known by GUFE. For example, there may be objects that are included
+in your GUFE object that come from another library, and are not GUFE
+tokenizables.
+
+When this happens, you will need to create and register a custom JSON
+codec. 
+
+Dumping arbitrary objects to JSON
+---------------------------------
+
+Advanced storage systems are space-efficient by only storing each object
+once. However, any :class:`.GufeTokenizable` can be dumped to a JSON file
+using the custom JSON handlers. Given a :class:`.GufeTokenizable` called
+``obj`` and a path-like called ``filename``, you can dump to JSON with this
+recipe:
+
+.. code::
+
+    import json
+    from gufe.tokenization import JSON_HANDLER
+    with open(filename, mode='w') as f:
+        json.dump(obj.to_dict(), f, cls=JSON_HANDLER.encoder)
+
+Similarly, you can reload the object with:
+
+.. code::
+
+    import json
+    from gufe.tokenization import JSON_HANDLER
+    with open(filename, mode='r') as f:
+        obj = json.load(f, cls=JSON_HANDLER.decoder)
+
+When your object has recursive references
+-----------------------------------------
+
+In some cases, your object may have recursive references to other objects.
+For example, you may have objects ``parent`` and ``child``, where
+``parent.children`` includes ``child`` and ``child.parent`` is ``parent``.
+This means that the object dependency graph is not a directed acyclic graph.
+The best solution here is to avoid this design pattern whenever possible.
+However, if it is unavoidable, 
+
+Understanding the theory: The GUFE key
+--------------------------------------
+
+One of the important concepts is that every GUFE object has a unique
+identifier, which we call its ``key``. The ``key`` is a string, typically
+in the format ``{CLASS_NAME}-{HEXADECIMAL_LABEL}``. The hexadecimal label is
+generated based on the contents of the class -- in particular, it is based
+on the non-default contents of the ``to_dict`` method. 
+
+
+Things storage systems may do
+-----------------------------
+
+Details on the implementation of storage systems is largely left to
+individual projects that build on GUFE. However, the existence of the GUFE
+key enables a number of powerful capabilities in storage.

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -58,6 +58,31 @@ As a very simple example, consider the following complete implementation:
         def _defaults(self):
             return {'baz': []}
 
+Testing your GufeTokenizable
+----------------------------
+
+We provide a convenience mix-in for testing that a
+:class:`.GufeTokenizable` will be correctly stored and reloaded. Here's an
+example of how to use it for the ``Foo`` class above:
+
+.. code::
+
+    import pytest
+    from gufe.tests.test_tokenization import GufeTokenizationTestsMixin
+
+    class TestFoo(GufeTokenizationTestsMixin):
+        cls = Foo
+        key = "Foo-8e7fd2803d73ef0cd9faceef751acfca"
+
+        @pytest.fixture
+        def instance(self):
+            return Foo(5, baz=['qux', 'quux', 'quuux'])
+
+You'll need to get the ``key`` from creating the ``instance`` once and
+recording ``str(obj.key)``-- since the key is stable, it shouldn't change
+(and, in fact, that is tested). This will add several tests to your test
+suite to ensure that you can save and reload your :class:`.GufeTokenizable`.
+
 .. TODO: add a section here about the various to_*_dict from_*_dict forms:
    shallow_dict; (deep) dict; keyed_dict
 

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -58,6 +58,9 @@ As a very simple example, consider the following complete implementation:
         def _defaults(self):
             return {'baz': []}
 
+.. TODO: add a section here about the various to_*_dict from_*_dict forms:
+   shallow_dict; (deep) dict; keyed_dict
+
 GufeTokenizables must be functionally immutable
 -----------------------------------------------
 
@@ -149,9 +152,12 @@ Similarly, you can reload the object with:
         obj = json.load(f, cls=JSON_HANDLER.decoder)
 
 Note that these objects are not space-efficient: that is, if you have
-the same object in memory stored at multiple locations (e.g., an identical
+the same object in memory referenced by multiple objects (e.g., an identical
 ``ProteinComponent`` in more than one ``ChemicalSystem``), then you will
 save multiple copies of its JSON representation.
+
+On reloading, tools that use the recommended ``from_dict`` method will undo
+do this duplication; see :ref:`gufe_memory_deduplication` for details.
 
 .. Using JSON codecs outside of JSON
 .. ---------------------------------
@@ -217,11 +223,12 @@ be used for store-by-reference.
 Deduplication of GufeTokenizables
 ---------------------------------
 
-There are two types of deduplication of GufeTokenizables. Objects are
+There are two types of deduplication of GufeTokenizables. Objects can be
 deduplicated on storage to disk because we store by reference to the gufe
 key. Additionally, objects are deduplicated in memory because we keep a
 registry of all instantiated GufeTokenizables.
 
+.. _gufe_memory-deduplication:
 
 Deduplication in memory
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This will add some developer-facing documentation on `gufe` serialization.

- [x] Describe abstract methods that devs need implement to make a `GufeTokenizable`
- [x] Describe how to add custom JSON codecs
- [x] Show how to use the custom JSON handlers
- [x] Explain what to do in the event of recursive references
- [x] Describe the features and functionality of the gufe key
- [x] Outline how storage systems can avoid duplication using gufe key to store by reference