### PR TITLE
Fix the way exception class names are made strings

### DIFF
--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -334,7 +334,7 @@ class ProtocolUnit(GufeTokenizable, ProtocolUnitMixin):
                 source_key=self.key,
                 inputs=inputs,
                 outputs=dict(),
-                exception=(str(type(e)), e.args),
+                exception=(e.__class__.__qualname__, e.args),
                 traceback=traceback.format_exc()
             )
 


### PR DESCRIPTION
```python
In [1]: v = ValueError("foo")

In [2]: str(type(v))
Out[2]: "<class 'ValueError'>"

In [3]: v.__class__.__qualname__
Out[3]: 'ValueError'
```

I think what we wanted was the latter, not the former -- at least, if we're going to try to reassemble the error message.