### PR TITLE
Added raise_error kwarg for protocoldag.execute, ProtocolUnit.execute

### DIFF
--- a/gufe/protocols/__init__.py
+++ b/gufe/protocols/__init__.py
@@ -1,3 +1,3 @@
 from .protocol import Protocol, ProtocolResult
-from .protocoldag import ProtocolDAG, ProtocolDAGResult, execute
+from .protocoldag import ProtocolDAG, ProtocolDAGResult, execute_DAG
 from .protocolunit import ProtocolUnit, ProtocolUnitResult, ProtocolUnitFailure, Context

--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -206,7 +206,9 @@ class ProtocolDAG(GufeTokenizable, DAGMixin):
 
 
 def execute(protocoldag: ProtocolDAG, *, 
-            shared: Optional[PathLike] = None) -> ProtocolDAGResult:
+            shared: Optional[PathLike] = None,
+            raise_error: bool = False,
+            ) -> ProtocolDAGResult:
     """Execute the full DAG in-serial, in process.
 
     This is intended for debug use for Protocol developers.

--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -205,10 +205,10 @@ class ProtocolDAG(GufeTokenizable, DAGMixin):
         return cls(**dct)
 
 
-def execute(protocoldag: ProtocolDAG, *, 
-            shared: Optional[PathLike] = None,
-            raise_error: bool = False,
-            ) -> ProtocolDAGResult:
+def execute_DAG(protocoldag: ProtocolDAG, *,
+                shared: Optional[PathLike] = None,
+                raise_error: bool = True,
+                ) -> ProtocolDAGResult:
     """Execute the full DAG in-serial, in process.
 
     This is intended for debug use for Protocol developers.
@@ -223,7 +223,9 @@ def execute(protocoldag: ProtocolDAG, *,
        is removed after. Used by some `ProtocolUnit`s to pass file contents
        to dependent `ProtocolUnit`s.
     raise_error : bool
-        If True, raise an exception if a ProtocolUnit fails.
+        If True, raise an exception if a ProtocolUnit fails, default True
+        if False, any exceptions will be stored as `ProtocolUnitFailure`
+        objects inside the returned `ProtocolDAGResult`
 
     Returns
     -------

--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -222,6 +222,8 @@ def execute(protocoldag: ProtocolDAG, *,
        Path to scratch space that persists across whole DAG execution, but
        is removed after. Used by some `ProtocolUnit`s to pass file contents
        to dependent `ProtocolUnit`s.
+    raise_error : bool
+        If True, raise an exception if a ProtocolUnit fails.
 
     Returns
     -------
@@ -244,7 +246,7 @@ def execute(protocoldag: ProtocolDAG, *,
         inputs = _pu_to_pur(unit.inputs, results)
 
         # execute
-        result = unit.execute(shared=shared_, **inputs)
+        result = unit.execute(shared=shared_, raise_error=raise_error, **inputs)
 
         # attach result to this `ProtocolUnit`
         results[unit.key] = result

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -281,6 +281,7 @@ class ProtocolUnit(GufeTokenizable):
     def execute(self, *, 
             shared: PathLike, 
             scratch: Optional[PathLike] = None, 
+            raise_error: bool = False,
             **inputs) -> Union[ProtocolUnitResult, ProtocolUnitFailure]:
         """Given `ProtocolUnitResult` s from dependencies, execute this `ProtocolUnit`
 
@@ -318,6 +319,9 @@ class ProtocolUnit(GufeTokenizable):
             )
 
         except Exception as e:
+            if raise_error:
+                raise
+
             result = ProtocolUnitFailure(
                 name=self._name,
                 source_key=self.key,

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -279,11 +279,11 @@ class ProtocolUnit(GufeTokenizable):
         return self._dependencies     # type: ignore
 
     def execute(self, *, 
-            shared: PathLike, 
-            scratch: Optional[PathLike] = None, 
-            raise_error: bool = False,
-            **inputs) -> Union[ProtocolUnitResult, ProtocolUnitFailure]:
-        """Given `ProtocolUnitResult` s from dependencies, execute this `ProtocolUnit`
+                shared: PathLike,
+                scratch: Optional[PathLike] = None,
+                raise_error: bool = False,
+                **inputs) -> Union[ProtocolUnitResult, ProtocolUnitFailure]:
+        """Given `ProtocolUnitResult` s from dependencies, execute this `ProtocolUnit`.
 
         Parameters
         ----------
@@ -294,7 +294,10 @@ class ProtocolUnit(GufeTokenizable):
         scratch : Optional[PathLike]
             Path to scratch space that persists during execution of this
             `ProtocolUnit`, but removed after.
-            
+        raise_error : bool
+            If True, raise any errors instead of catching and returning a
+            `ProtocolUnitFailure`, default False
+
         **inputs
             Keyword arguments giving the named inputs to `_execute`.
             These can include `ProtocolUnitResult` objects from `ProtocolUnit`

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -212,7 +212,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
             stateA=solvated_ligand, stateB=vacuum_ligand, name="a broken dummy run"
         )
 
-        dagfailure: ProtocolDAGResult = execute_DAG(dag)
+        dagfailure: ProtocolDAGResult = execute_DAG(dag, raise_error=False)
 
         return protocol, dag, dagfailure
 

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -21,7 +21,7 @@ from gufe.protocols import (
     ProtocolUnitFailure,
 )
 
-from gufe.protocols.protocoldag import execute
+from gufe.protocols.protocoldag import execute_DAG
 
 from .test_tokenization import GufeTokenizableTestsMixin
 
@@ -201,7 +201,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
         dag = protocol.create(
             stateA=solvated_ligand, stateB=vacuum_ligand, name="a dummy run"
         )
-        dagresult: ProtocolDAGResult = execute(dag)
+        dagresult: ProtocolDAGResult = execute_DAG(dag)
 
         return protocol, dag, dagresult
 
@@ -212,7 +212,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
             stateA=solvated_ligand, stateB=vacuum_ligand, name="a broken dummy run"
         )
 
-        dagfailure: ProtocolDAGResult = execute(dag)
+        dagfailure: ProtocolDAGResult = execute_DAG(dag)
 
         return protocol, dag, dagfailure
 
@@ -268,7 +268,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
         )
 
         with pytest.raises(ValueError, match="I have failed my mission"):
-            execute(dag, raise_error=True)
+            execute_DAG(dag, raise_error=True)
 
     def test_create_execute_gather(self, protocol_dag):
         protocol, dag, dagresult = protocol_dag
@@ -483,7 +483,7 @@ class TestNoDepProtocol:
 
         dag = p.create(None, None)
 
-        dag_result = execute(dag)
+        dag_result = execute_DAG(dag)
 
         assert dag_result.ok()
 

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -261,6 +261,15 @@ class TestProtocol(GufeTokenizableTestsMixin):
 
         assert len(succeeded_units) > 0
 
+    def test_dag_execute_failure_raise_error(self, solvated_ligand, vacuum_ligand):
+        protocol = BrokenProtocol(settings=None)
+        dag = protocol.create(
+            stateA=solvated_ligand, stateB=vacuum_ligand, name="a broken dummy run"
+        )
+
+        with pytest.raises(ValueError, match="I have failed my mission"):
+            execute(dag, raise_error=True)
+
     def test_create_execute_gather(self, protocol_dag):
         protocol, dag, dagresult = protocol_dag
 

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -85,7 +85,7 @@ class GufeTokenizableTestsMixin(abc.ABC):
         """
         ...
 
-    def teardown(self):
+    def teardown_method(self):
         TOKENIZABLE_REGISTRY.clear()
 
     def test_to_dict_roundtrip(self, instance):

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -6,7 +6,7 @@ import io
 
 from gufe.tests.test_tokenization import GufeTokenizableTestsMixin
 from gufe.transformations import Transformation, NonTransformation
-from gufe.protocols.protocoldag import execute
+from gufe.protocols.protocoldag import execute_DAG
 
 from .test_protocol import DummyProtocol, DummyProtocolResult
 from .test_tokenization import GufeTokenizableTestsMixin
@@ -48,7 +48,7 @@ class TestTransformation(GufeTokenizableTestsMixin):
         assert isinstance(tnf.protocol, DummyProtocol)
 
         protocoldag = tnf.create()
-        protocoldagresult = execute(protocoldag)
+        protocoldagresult = execute_DAG(protocoldag)
 
         protocolresult = tnf.gather([protocoldagresult])
 
@@ -107,7 +107,7 @@ class TestNonTransformation(GufeTokenizableTestsMixin):
         assert isinstance(ntnf.protocol, DummyProtocol)
 
         protocoldag = ntnf.create()
-        protocoldagresult = execute(protocoldag)
+        protocoldagresult = execute_DAG(protocoldag)
 
         protocolresult = ntnf.gather([protocoldagresult])
 


### PR DESCRIPTION
This change raises the error from a given ProtocolUnit.execute call if `raise_error=True`. In `protocoldag.execute`, giving this same kwarg will cause the method to stop on hitting an exception in the ProtocolUnit it is executing. This makese debugging easier when necessary.
