### PR TITLE
Protocoldagresult multiple results

### DIFF
--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -150,7 +150,7 @@ class ProtocolDAGResult(GufeTokenizable, DAGMixin):
         ----
         These are returned in DAG order
         """
-        return [r for r in self.protocol_unit_results if r.ok()]  # type: ignore
+        return [r for r in self.protocol_unit_results if r.ok()]
 
     def unit_to_results(self, protocol_unit: ProtocolUnit) -> list[ProtocolUnitResult]:
         try:

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -49,7 +49,7 @@ def _list_dependencies(inputs, cls):
     return deps
 
 
-class ProtocolUnitResultBase(GufeTokenizable):
+class ProtocolUnitResult(GufeTokenizable):
     def __init__(self, *,
             name: Optional[str] = None,
             source_key: GufeKey,
@@ -125,37 +125,15 @@ class ProtocolUnitResultBase(GufeTokenizable):
     def dependencies(self) -> list[ProtocolUnitResult]:
         """All results that this result was dependent on"""
         if self._dependencies is None:
-            self._dependencies = _list_dependencies(self._inputs, ProtocolUnitResultBase)
+            self._dependencies = _list_dependencies(self._inputs, ProtocolUnitResult)
         return self._dependencies     # type: ignore
-
-
-class ProtocolUnitResult(ProtocolUnitResultBase):
-    """Result for a single `ProtocolUnit` execution.
-
-    Attributes
-    ----------
-    name : Optional[str]
-        Name of the `ProtocolUnit` that produced this `ProtocolUnitResult`.
-    source_key : GufeKey
-        Key of the `ProtocolUnit` that produced this `ProtocolUnitResult`
-    inputs : Dict[str, Any]
-        Inputs to the `ProtocolUnit` that produced this
-        `ProtocolUnitResult`. Includes any `ProtocolUnitResult` objects this
-        `ProtocolUnitResult` was dependent on.
-    outputs : Dict[str, Any]
-        Outputs from the `ProtocolUnit.execute` that generated this
-        `ProtocolUnitResult`.
-    dependencies : list[ProtocolUnitResult]
-        A list of the `ProtocolUnitResult` objects depended upon.
-
-    """
 
     @staticmethod
     def ok() -> bool:
         return True
 
 
-class ProtocolUnitFailure(ProtocolUnitResultBase):
+class ProtocolUnitFailure(ProtocolUnitResult):
     """Failed result for a single `ProtocolUnit` execution."""
 
     def __init__(self, *, name=None, source_key, inputs, outputs, _key=None, exception, traceback):

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -368,7 +368,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
 
         def test_protocol_unit_failures(self, instance: ProtocolDAGResult):
             assert len(instance.protocol_unit_failures) == 0
-            
+
         def test_protocol_unit_successes(self, instance: ProtocolDAGResult):
             assert len(instance.protocol_unit_successes) == 23
             assert all(isinstance(i, ProtocolUnitResult) for i in instance.protocol_unit_successes)

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -226,7 +226,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
         assert finishresult.name == "the end"
 
         # gather SimulationUnits
-        simulationresults = [dagresult.unit_to_result(pu)
+        simulationresults = [dagresult.unit_to_results(pu)[0]
                              for pu in dagresult.protocol_units
                              if isinstance(pu, SimulationUnit)]
 
@@ -358,7 +358,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
         def test_unit_to_result(self, instance: ProtocolDAGResult):
             # check that every unit has a result that we can retrieve
             for pu in instance.protocol_units:
-                pur: ProtocolUnitResult = instance.unit_to_result(pu)
+                pur: ProtocolUnitResult = instance.unit_to_results(pu)[0]
                 assert pur.source_key == pu.key
 
         def test_result_to_unit(self, instance: ProtocolDAGResult):


### PR DESCRIPTION
Somewhat of a rebuttal to #102

Allows many `ProtocolUnitResult`s per `ProtocolUnit` in a `ProtocolDAGResult`