### PR TITLE
Fix issues with custom JSON codecs

### DIFF
--- a/gufe/custom_json.py
+++ b/gufe/custom_json.py
@@ -66,8 +66,8 @@ class JSONCodec(object):
             dct = {}
             if self.cls:
                 dct.update({
-                    '__class__': self.cls.__name__,
-                    '__module__': self.cls.__module__,
+                    '__class__': obj.__class__.__qualname__,
+                    '__module__': obj.__class__.__module__,
                     ':is_custom:': True,
                 })
             # we let the object override __class__ and __module__ if needed

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -15,9 +15,14 @@ import json
 from typing import Dict, Any, Callable, Union, List, Tuple
 import weakref
 from gufe.custom_json import JSONSerializerDeserializer
-from gufe.custom_codecs import PATH_CODEC, NUMPY_CODEC, BYTES_CODEC
+from gufe.custom_codecs import (
+    PATH_CODEC, NUMPY_CODEC, BYTES_CODEC, SETTINGS_CODEC, OPENFF_UNIT_CODEC,
+    OPENFF_QUANTITY_CODEC
+)
 
-_default_json_codecs = [PATH_CODEC, NUMPY_CODEC, BYTES_CODEC]
+_default_json_codecs = [PATH_CODEC, NUMPY_CODEC, BYTES_CODEC,
+                        SETTINGS_CODEC, OPENFF_UNIT_CODEC,
+                        OPENFF_QUANTITY_CODEC]
 JSON_HANDLER = JSONSerializerDeserializer(_default_json_codecs)
 
 # maps qualified name strings to the class


### PR DESCRIPTION
This fixes issues with inheritance in classes given to JSON codecs. It also adds codecs for `Settings` (technically `SettingsBaseModel`) and for OpenFF units/quantities (I though we already had these? Apparently not.)

The following now works for me, when this branch is combined with the cleanup in #101 making it easier to deal with forcefield settings:

```python
import json
from gufe.settings import settings
from gufe.tokenization import JSON_HANDLER
from openff.units import unit

s = settings.Settings(
    forcefield_file="foo.bar",
    forcefield_settings=settings.ForcefieldSettings(),
    thermo_settings=settings.ThermoSettings(temperature=300 * unit.kelvin)
)
dumped = json.dumps(s, cls=JSON_HANDLER.encoder)
loaded = json.loads(dumped, cls=JSON_HANDLER.decoder)
```

There's enough in here that I thought I'd make is a separate PR from #101; but this will be very useful to some of the goals over there.