### PR TITLE
Made ProtocolDAGResult.terminal_protocol_unit_results a property

### DIFF
--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -206,6 +206,7 @@ class ProtocolDAGResult(GufeTokenizable, DAGMixin):
         return all(any(pur.ok() for pur in self._unit_result_mapping[pu])
                    for pu in self._protocol_units)
 
+    @property
     def terminal_protocol_unit_results(self) -> list[ProtocolUnitResult]:
         """Get ProtocolUnits that terminate the DAG
 

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -245,7 +245,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
     def test_terminal_units(self, protocol_dag):
         prot, dag, res = protocol_dag
 
-        finals = res.terminal_protocol_unit_results()
+        finals = res.terminal_protocol_unit_results
 
         assert len(finals) == 1
         assert isinstance(finals[0], ProtocolUnitResult)
@@ -514,7 +514,7 @@ class TestNoDepProtocol:
 
         dag_result = execute_DAG(dag)
 
-        terminal_results = dag_result.terminal_protocol_unit_results()
+        terminal_results = dag_result.terminal_protocol_unit_results
 
         assert len(terminal_results) == 3
 


### PR DESCRIPTION
This gives parity with the other properties on this object.
