### PR TITLE
Fix #128

### DIFF
--- a/gufe/__init__.py
+++ b/gufe/__init__.py
@@ -34,3 +34,5 @@ from .protocols import (
 from .transformations import Transformation, NonTransformation
 
 from .network import AlchemicalNetwork
+
+from .settings import Settings

--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -1,7 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
-import abc
+from collections import abc
 from typing import Dict, Optional
 
 import numpy as np
@@ -10,7 +10,7 @@ from .tokenization import GufeTokenizable
 from .components import Component
 
 
-class ChemicalSystem(abc.Mapping, GufeTokenizable):
+class ChemicalSystem(GufeTokenizable, abc.Mapping):
     """A node of an alchemical network.
 
     Attributes
@@ -84,7 +84,7 @@ class ChemicalSystem(abc.Mapping, GufeTokenizable):
     def __hash__(self):
         # apparently be defining a custom __eq__ here, we lose super's
         # __hash__, and need to redefine it
-        return super(GufeTokenizable, self).__hash__()
+        return super().__hash__()
 
     def _to_dict(self):
         return {

--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -1,7 +1,6 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
-from collections import abc
 from typing import Dict, Optional
 
 import numpy as np
@@ -10,7 +9,7 @@ from .tokenization import GufeTokenizable
 from .components import Component
 
 
-class ChemicalSystem(abc.Mapping, GufeTokenizable):
+class ChemicalSystem(GufeTokenizable):
     """A node of an alchemical network.
 
     Attributes
@@ -82,13 +81,9 @@ class ChemicalSystem(abc.Mapping, GufeTokenizable):
         return True
 
     def __hash__(self):
-        return hash(
-            (
-                tuple(sorted(self._components.items())),
-                self._box_vectors.tobytes(),
-                self._name,
-            )
-        )
+        # apparently be defining a custom __eq__ here, we lose super's
+        # __hash__, and need to redefine it
+        return super().__hash__()
 
     def _to_dict(self):
         return {

--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -1,6 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
+import abc
 from typing import Dict, Optional
 
 import numpy as np
@@ -9,7 +10,7 @@ from .tokenization import GufeTokenizable
 from .components import Component
 
 
-class ChemicalSystem(GufeTokenizable):
+class ChemicalSystem(abc.Mapping, GufeTokenizable):
     """A node of an alchemical network.
 
     Attributes
@@ -83,7 +84,7 @@ class ChemicalSystem(GufeTokenizable):
     def __hash__(self):
         # apparently be defining a custom __eq__ here, we lose super's
         # __hash__, and need to redefine it
-        return super().__hash__()
+        return super(GufeTokenizable, self).__hash__()
 
     def _to_dict(self):
         return {

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -119,7 +119,9 @@ class Protocol(GufeTokenizable):
         return True
 
     def __hash__(self):
-        return hash((self.__class__.__name__, self._settings))
+        # apparently be defining a custom __eq__ here, we lose super's
+        # __hash__, and need to redefine it
+        return super().__hash__()
 
     @classmethod
     def _defaults(cls):

--- a/gufe/settings/__init__.py
+++ b/gufe/settings/__init__.py
@@ -1,0 +1,1 @@
+from .models import Settings, ThermoSettings, OpenMMSystemGeneratorFFSettings

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -108,15 +108,9 @@ class Transformation(GufeTokenizable):
         return True
 
     def __hash__(self):
-        return hash(
-            (
-                self._stateA,
-                self._stateB,
-                self._mapping,
-                self._name,
-                self._protocol,
-            )
-        )
+        # apparently be defining a custom __eq__ here, we lose super's
+        # __hash__, and need to redefine it
+        return super().__hash__()
 
     def _to_dict(self) -> dict:
         return {


### PR DESCRIPTION
Sets the `__hash__` method for each major `GufeTokenizable` to that of `GufeTokenizable` itself. This removes the redundancy of existing implementations and gives consistent behavior for these objects.
