### PR TITLE
Update Protocol tests to use Settings object

### DIFF
--- a/gufe/__init__.py
+++ b/gufe/__init__.py
@@ -22,6 +22,9 @@ from .mapping import (
     AtomMapping, AtomMapper,  # more specific to atom based components
     LigandAtomMapping,
 )
+
+from .settings import Settings
+
 from .protocols import (
     Protocol,  # description of a method
     ProtocolUnit,  # the individual step within a method
@@ -34,5 +37,3 @@ from .protocols import (
 from .transformations import Transformation, NonTransformation
 
 from .network import AlchemicalNetwork
-
-from .settings import Settings

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -73,9 +73,9 @@ class ProtocolResult(GufeTokenizable):
 class Protocol(GufeTokenizable):
     """A protocol that implements an alchemical transformation.
 
-    Takes a `ProtocolSettings` object specific to the protocol on init.
-    This configures the protocol for repeated execution on `ChemicalSystem`
-    objects.
+    Takes a `Settings` object customised for this protocol on init.
+    This configures the protocol for repeated execution on (pairs of)
+    `ChemicalSystem` objects.
 
     This is an abstract base class; individual Protocol implementations
     should be subclasses of this class. The following methods should be
@@ -139,7 +139,7 @@ class Protocol(GufeTokenizable):
     def _default_settings(cls) -> Settings:
         """Method to override in custom `Protocol` subclasses.
 
-        Gives a usable instance of `ProtocolSettings` that function as
+        Gives a usable instance of `Settings` that function as
         reasonable defaults for this `Protocol` subclass.
 
         """

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -9,7 +9,7 @@ import abc
 from typing import Optional, Iterable, Any, Union
 from openff.units import Quantity
 
-from .. import Settings
+from ..settings import Settings
 from ..tokenization import GufeTokenizable, GufeKey
 from ..chemicalsystem import ChemicalSystem
 from ..mapping import ComponentMapping
@@ -91,23 +91,22 @@ class Protocol(GufeTokenizable):
         Corresponding `ProtocolResult` subclass
 
     """
-
+    _settings: Settings
     result_cls: type[ProtocolResult]
 
-    def __init__(self, settings: Optional[Settings] = None):
-        """Create a new `Protocol` instance.
+    def __init__(self, settings: Settings):
+        """Create a new ``Protocol`` instance.
 
         Parameters
         ----------
         settings : Settings
-            The full settings for this `Protocol` instance.
-
+            The full settings for this ``Protocol`` instance.
         """
         self._settings = settings
 
     @property
-    def settings(self):
-        """The full settings for this `Protocol` instance."""
+    def settings(self) -> Settings:
+        """The full settings for this ``Protocol`` instance."""
         return self._settings
 
     def __eq__(self, other):

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -9,7 +9,7 @@ import abc
 from typing import Optional, Iterable, Any, Union
 from openff.units import Quantity
 
-
+from .. import Settings
 from ..tokenization import GufeTokenizable, GufeKey
 from ..chemicalsystem import ChemicalSystem
 from ..mapping import ComponentMapping
@@ -94,12 +94,12 @@ class Protocol(GufeTokenizable):
 
     result_cls: type[ProtocolResult]
 
-    def __init__(self, settings=None):
+    def __init__(self, settings: Optional[Settings] = None):
         """Create a new `Protocol` instance.
 
         Parameters
         ----------
-        settings : ProtocolSettings
+        settings : Settings
             The full settings for this `Protocol` instance.
 
         """
@@ -136,7 +136,7 @@ class Protocol(GufeTokenizable):
 
     @classmethod
     @abc.abstractmethod
-    def _default_settings(cls) -> "ProtocolSettings":     # type: ignore
+    def _default_settings(cls) -> Settings:
         """Method to override in custom `Protocol` subclasses.
 
         Gives a usable instance of `ProtocolSettings` that function as
@@ -146,7 +146,7 @@ class Protocol(GufeTokenizable):
         raise NotImplementedError()
 
     @classmethod
-    def default_settings(cls) -> "ProtocolSettings":      # type: ignore
+    def default_settings(cls) -> Settings:
         """Get the default settings for this `Protocol`.
 
         These can be modified and passed in as the `settings` for a new

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -73,9 +73,9 @@ class ProtocolResult(GufeTokenizable):
 class Protocol(GufeTokenizable):
     """A protocol that implements an alchemical transformation.
 
-    Takes a `Settings` object customised for this protocol on init.
+    Takes a ``Settings`` object customised for this protocol on init.
     This configures the protocol for repeated execution on (pairs of)
-    `ChemicalSystem` objects.
+    ``ChemicalSystem`` objects.
 
     This is an abstract base class; individual Protocol implementations
     should be subclasses of this class. The following methods should be
@@ -139,7 +139,7 @@ class Protocol(GufeTokenizable):
     def _default_settings(cls) -> Settings:
         """Method to override in custom `Protocol` subclasses.
 
-        Gives a usable instance of `Settings` that function as
+        Gives a usable instance of ``Settings`` that function as
         reasonable defaults for this `Protocol` subclass.
 
         """

--- a/gufe/settings/__init__.py
+++ b/gufe/settings/__init__.py
@@ -1,1 +1,4 @@
-from .models import Settings, ThermoSettings, OpenMMSystemGeneratorFFSettings
+from .models import (
+    Settings, ThermoSettings, OpenMMSystemGeneratorFFSettings,
+    ProtocolSettings,
+)

--- a/gufe/settings/__init__.py
+++ b/gufe/settings/__init__.py
@@ -1,4 +1,10 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/gufe
 from .models import (
-    Settings, ThermoSettings, OpenMMSystemGeneratorFFSettings,
+    Settings,
+    ThermoSettings,
+    BaseForcefieldSettings,
+    OpenMMSystemGeneratorFFSettings,
     ProtocolSettings,
+    SettingsBaseModel,
 )

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -1,3 +1,5 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/gufe
 """
 Pydantic models used for storing settings.
 """

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -87,7 +87,7 @@ class Settings(SettingsBaseModel):
     settings_version: int = 0
     forcefield_settings: OpenMMSystemGeneratorFFSettings
     thermo_settings: ThermoSettings
-    protocol_settings: Union[ProtocolSettings, None]
+    protocol_settings: type[ProtocolSettings]
 
     @classmethod
     def get_defaults(cls):

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -87,7 +87,7 @@ class Settings(SettingsBaseModel):
     settings_version: int = 0
     forcefield_settings: OpenMMSystemGeneratorFFSettings
     thermo_settings: ThermoSettings
-    protocol_settings: type[ProtocolSettings]
+    protocol_settings: Union[ProtocolSettings, None]
 
     @classmethod
     def get_defaults(cls):

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -140,7 +140,7 @@ class DummyProtocol(Protocol):
         # create several units that would each run an independent simulation
         simulations: List[ProtocolUnit] = [
             SimulationUnit(settings=self.settings, name=f"sim {i}", window=i, initialization=alpha)
-            for i in range(self.settings.protocol_settings.n_repeats)
+            for i in range(self.settings.protocol_settings.n_repeats)  # type: ignore
         ]
 
         # gather results from simulations, finalize outputs
@@ -176,7 +176,7 @@ class BrokenProtocol(DummyProtocol):
         stateB: ChemicalSystem,
         mapping: Optional[dict[str, ComponentMapping]] = None,
         extends: Optional[ProtocolDAGResult] = None,
-    ) -> nx.DiGraph:
+    ) -> list[ProtocolUnit]:
 
         # convert protocol inputs into starting points for independent simulations
         alpha = InitializeUnit(

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -16,20 +16,21 @@ def absolute_transformation(solvated_ligand, solvated_complex):
     return Transformation(
         solvated_ligand,
         solvated_complex,
-        protocol=DummyProtocol(settings=None),
+        protocol=DummyProtocol(settings=DummyProtocol.default_settings()),
         mapping=None,
     )
 
 
 @pytest.fixture
 def complex_equilibrium(solvated_complex):
-    return NonTransformation(solvated_complex, protocol=DummyProtocol(settings=None))
+    return NonTransformation(solvated_complex,
+                             protocol=DummyProtocol(settings=DummyProtocol.default_settings()))
 
 
 class TestTransformation(GufeTokenizableTestsMixin):
 
     cls = Transformation
-    key = "Transformation-71aa10f49247f04d3efb0fd697980b46"
+    key = "Transformation-af747630b54613042022fdb183a27c14"
 
     @pytest.fixture
     def instance(self, absolute_transformation):
@@ -53,7 +54,9 @@ class TestTransformation(GufeTokenizableTestsMixin):
 
         assert isinstance(protocolresult, DummyProtocolResult)
 
-        len(protocolresult.data) == 1
+        assert len(protocolresult.data) == 2
+        assert 'logs' in protocolresult.data
+        assert 'key_results' in protocolresult.data
 
     def test_protocol_extend(self, absolute_transformation):
         tnf = absolute_transformation
@@ -70,12 +73,13 @@ class TestTransformation(GufeTokenizableTestsMixin):
 
         assert isinstance(protocolresult, DummyProtocolResult)
 
-        len(protocolresult.data) == 2
+        assert len(protocolresult.data) == 2
 
     def test_equality(self, absolute_transformation, solvated_ligand, solvated_complex):
 
         opposite = Transformation(
-            solvated_complex, solvated_ligand, protocol=DummyProtocol(settings=None)
+            solvated_complex, solvated_ligand,
+            protocol=DummyProtocol(settings=DummyProtocol.default_settings())
         )
         assert absolute_transformation != opposite
 
@@ -89,7 +93,7 @@ class TestTransformation(GufeTokenizableTestsMixin):
         identical = Transformation(
             solvated_ligand,
             solvated_complex,
-            protocol=DummyProtocol(settings=None),
+            protocol=DummyProtocol(settings=DummyProtocol.default_settings()),
             mapping=None,
         )
         assert absolute_transformation == identical
@@ -105,7 +109,7 @@ class TestTransformation(GufeTokenizableTestsMixin):
 class TestNonTransformation(GufeTokenizableTestsMixin):
 
     cls = NonTransformation
-    key = "NonTransformation-b1040a001ede0358dfec851b6737e654"
+    key = "NonTransformation-d515c0765f4e8bde57bc586d10e29e56"
 
     @pytest.fixture
     def instance(self, complex_equilibrium):
@@ -129,7 +133,9 @@ class TestNonTransformation(GufeTokenizableTestsMixin):
 
         assert isinstance(protocolresult, DummyProtocolResult)
 
-        len(protocolresult.data) == 1
+        assert len(protocolresult.data) == 2
+        assert 'logs' in protocolresult.data
+        assert 'key_results' in protocolresult.data
 
     def test_protocol_extend(self, complex_equilibrium):
         ntnf = complex_equilibrium
@@ -146,7 +152,7 @@ class TestNonTransformation(GufeTokenizableTestsMixin):
 
         assert isinstance(protocolresult, DummyProtocolResult)
 
-        len(protocolresult.data) == 2
+        assert len(protocolresult.data) == 2
 
     def test_equality(self, complex_equilibrium, solvated_ligand, solvated_complex):
 
@@ -156,7 +162,7 @@ class TestNonTransformation(GufeTokenizableTestsMixin):
         assert complex_equilibrium != different_protocol_settings
 
         identical = NonTransformation(
-            solvated_complex, protocol=DummyProtocol(settings=None)
+            solvated_complex, protocol=DummyProtocol(settings=DummyProtocol.default_settings())
         )
         assert complex_equilibrium == identical
 

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -167,7 +167,7 @@ class TestNonTransformation(GufeTokenizableTestsMixin):
         assert complex_equilibrium == identical
 
         different_system = NonTransformation(
-            solvated_ligand, protocol=DummyProtocol(settings=None)
+            solvated_ligand, protocol=DummyProtocol(settings=DummyProtocol.default_settings())
         )
         assert complex_equilibrium != different_system
 

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -4,7 +4,6 @@
 import pytest
 import io
 
-from gufe.tests.test_tokenization import GufeTokenizableTestsMixin
 from gufe.transformations import Transformation, NonTransformation
 from gufe.protocols.protocoldag import execute_DAG
 


### PR DESCRIPTION
Updates the tests around `DummyProtocol` to use a `Settings` object internally, making the tests more relevant for real world cases