### PR TITLE
Add test data to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,8 @@ include versioneer.py
 include gufe/_version.py
 
 include gufe/vendor/pdb_file/data/*.xml
+recursive-include gufe/tests/data/ *.pdb
+recursive-include gufe/tests/data/ *.sdf
+recursive-include gufe/tests/data/ *.cif
+recursive-include gufe/tests/data/ *.mol2
+recursive-include gufe/tests/data/ *.json


### PR DESCRIPTION
We had not been including test data in MANIFEST.in, meaning that `pytest --pyargs gufe` would fail because the files weren't including in the installation.

I know that @richardjgowers has been talking about moving to a separate package to manage test data. That may be a better solution than this, but it would be nice to push out a release with this quickly: (1) running tests is one of the first things I recommend when a user has an installation issue (can often point to problems like this); (2) I think this is blocking OpenFreeEnergy/openfe#266.