### PR TITLE
Make `GufeTokenizable` use a true flyweight pattern

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -49,6 +49,8 @@ class ExplicitMoleculeComponent(Component):
     representations. Specific file formats, such as SDF for small molecules
     or PDB for proteins, should be implemented in subclasses.
     """
+    _rdkit: Chem.Mol
+    _name: str
 
     def __init__(self, rdkit: RDKitMol, name: str = ""):
         name = _ensure_ofe_name(rdkit, name)

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -37,11 +37,6 @@ def _ensure_ofe_name(mol: RDKitMol, name: str) -> str:
     return name
 
 
-def _ensure_ofe_version(mol: RDKitMol):
-    """Ensure the rdkit representation has the current version associated"""
-    mol.SetProp("ofe-version", __version__)
-
-
 class ExplicitMoleculeComponent(Component):
     """Base class for explicit molecules.
 
@@ -54,7 +49,6 @@ class ExplicitMoleculeComponent(Component):
 
     def __init__(self, rdkit: RDKitMol, name: str = ""):
         name = _ensure_ofe_name(rdkit, name)
-        _ensure_ofe_version(rdkit)
         conformers = list(rdkit.GetConformers())
         if not conformers:
             raise ValueError("Molecule was provided with no conformers.")

--- a/gufe/components/smallmoleculecomponent.py
+++ b/gufe/components/smallmoleculecomponent.py
@@ -66,13 +66,13 @@ def _setprops(obj, d: dict) -> None:
     # add props onto rdkit "obj" (atom/bond/mol/conformer)
     # props are guaranteed one of Bool, Int, Float or String type
     for k, v in d.items():
-        if isinstance(v, int):
+        if isinstance(v, bool):
+            obj.SetBoolProp(k, v)
+        elif isinstance(v, int):
             obj.SetIntProp(k, v)
         elif isinstance(v, float):
             obj.SetDoubleProp(k, v)
-        elif isinstance(v, bool):
-            obj.SetBoolProp(k, v)
-        else:  # string
+        else:  # isinstance(v, str):
             obj.SetProp(k, v)
 
 

--- a/gufe/components/smallmoleculecomponent.py
+++ b/gufe/components/smallmoleculecomponent.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger('openff.toolkit')
 logger.setLevel(logging.ERROR)
 from openff.toolkit.topology import Molecule as OFFMolecule
-from openff.units import unit
+from typing import Any
 
 from rdkit import Chem
 
@@ -206,7 +206,7 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
         # but this format slowly evolves, so the future hash of a SMC could change if rdkit were updated
         # this is based on that method, with some irrelevant fields cut out
 
-        output = {}
+        output: dict[str, Any] = {}
 
         atoms = []
         for atom in self._rdkit.GetAtoms():

--- a/gufe/components/smallmoleculecomponent.py
+++ b/gufe/components/smallmoleculecomponent.py
@@ -50,8 +50,6 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
     def to_sdf(self) -> str:
         """Create a string based on SDF.
 
-        This is the primary serialization mechanism for this class.
-
         See Also
         --------
         :meth:`.from_sdf_string` : create an object from the output of this
@@ -68,8 +66,6 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
     @classmethod
     def from_sdf_string(cls, sdf_str: str):
         """Create ``SmallMoleculeComponent`` from SDF-formatted string.
-
-        This is the primary deserialization mechanism for this class.
 
         Parameters
         ----------

--- a/gufe/mapping/ligandatommapping.py
+++ b/gufe/mapping/ligandatommapping.py
@@ -77,8 +77,8 @@ class LigandAtomMapping(AtomMapping):
         """Serialize to dict"""
         return {
             # openff serialization doesn't go deep, so stringify at this level
-            'componentA': json.dumps(self.componentA.to_dict(), sort_keys=True),
-            'componentB': json.dumps(self.componentB.to_dict(), sort_keys=True),
+            'componentA': self.componentA.to_dict(),
+            'componentB': self.componentB.to_dict(),
             'componentA_to_componentB': self._compA_to_compB,
             'annotations': json.dumps(self.annotations),
         }

--- a/gufe/tests/conftest.py
+++ b/gufe/tests/conftest.py
@@ -82,13 +82,9 @@ ALL_PDB_LOADERS = dict(**PDB_BENCHMARK_LOADERS, **PDB_FILE_LOADERS)
 ## data file paths
 
 @pytest.fixture
-def serialization_template():
-    def inner(filename):
-        loc = "gufe.tests.data"
-        tmpl = importlib.resources.read_text(loc, filename)
-        return tmpl.format(OFE_VERSION=gufe.__version__)
-
-    return inner
+def ethane_sdf():
+    with importlib.resources.path("gufe.tests.data", "ethane.sdf") as f:
+        yield str(f)
 
 
 @pytest.fixture

--- a/gufe/tests/data/ethane.sdf
+++ b/gufe/tests/data/ethane.sdf
@@ -10,7 +10,4 @@ M  END
 >  <ofe-name>
 ethane
 
->  <ofe-version>
-{OFE_VERSION}
-
 $$$$

--- a/gufe/tests/test_chemicalsystem.py
+++ b/gufe/tests/test_chemicalsystem.py
@@ -131,7 +131,7 @@ def test_sorting(solvated_complex, solvated_ligand):
 class TestChemicalSystem(GufeTokenizableTestsMixin):
 
     cls = ChemicalSystem
-    key = "ChemicalSystem-21dceb153fdfb4865b87af060e6ecf15"
+    key = "ChemicalSystem-6dcde733b866dd78dcb757e5b86bc6dd"
 
     @pytest.fixture
     def instance(self, solv_comp, toluene_ligand_comp):

--- a/gufe/tests/test_chemicalsystem.py
+++ b/gufe/tests/test_chemicalsystem.py
@@ -131,7 +131,7 @@ def test_sorting(solvated_complex, solvated_ligand):
 class TestChemicalSystem(GufeTokenizableTestsMixin):
 
     cls = ChemicalSystem
-    key = "ChemicalSystem-6dcde733b866dd78dcb757e5b86bc6dd"
+    key = "ChemicalSystem-1f244420be5cf662c0f804b052ef2a1e"
 
     @pytest.fixture
     def instance(self, solv_comp, toluene_ligand_comp):

--- a/gufe/tests/test_ligandatommapping.py
+++ b/gufe/tests/test_ligandatommapping.py
@@ -166,43 +166,6 @@ def test_draw_mapping_svg(tmpdir, other_mapping):
         assert filed.exists()
 
 
-class TestLigandAtomMappingSerialization:
-    def test_to_dict(self, benzene_phenol_mapping):
-        d = benzene_phenol_mapping.to_dict()
-
-        assert isinstance(d, dict)
-        assert 'componentA' in d
-        assert 'componentB' in d
-        assert 'annotations' in d
-        assert isinstance(d['componentA'], str)
-
-    def test_deserialize_roundtrip(self, benzene_phenol_mapping,
-                                   benzene_anisole_mapping):
-
-        roundtrip = LigandAtomMapping.from_dict(
-                        benzene_phenol_mapping.to_dict())
-
-        assert roundtrip == benzene_phenol_mapping
-
-        # We don't check coordinates since that's already done in guefe for
-        # SmallMoleculeComponent
-
-        assert roundtrip != benzene_anisole_mapping
-
-    def test_file_roundtrip(self, benzene_phenol_mapping, tmpdir):
-        with tmpdir.as_cwd():
-            with open('tmpfile.json', 'w') as f:
-                f.write(json.dumps(benzene_phenol_mapping.to_dict()))
-
-            with open('tmpfile.json', 'r') as f:
-                d = json.load(f)
-
-            assert isinstance(d, dict)
-            roundtrip = LigandAtomMapping.from_dict(d)
-
-            assert roundtrip == benzene_phenol_mapping
-
-
 def test_annotated_atommapping_hash_eq(simple_mapping,
                                        annotated_simple_mapping):
     assert annotated_simple_mapping != simple_mapping

--- a/gufe/tests/test_mapping.py
+++ b/gufe/tests/test_mapping.py
@@ -47,7 +47,7 @@ class ExampleMapping(AtomMapping):
 
 class TestMappingAbstractClass(GufeTokenizableTestsMixin):
     cls = ExampleMapping
-    key = 'ExampleMapping-98bc8ebc1d01d9dc29783d1061149676'
+    key = 'ExampleMapping-ea9e102cdfddb0e243bde58074dd729c'
 
     @pytest.fixture
     def instance(self, benzene, toluene):

--- a/gufe/tests/test_mapping.py
+++ b/gufe/tests/test_mapping.py
@@ -47,7 +47,7 @@ class ExampleMapping(AtomMapping):
 
 class TestMappingAbstractClass(GufeTokenizableTestsMixin):
     cls = ExampleMapping
-    key = 'ExampleMapping-1fdcf491eceaabd48f0d3b0afbff5769'
+    key = 'ExampleMapping-98bc8ebc1d01d9dc29783d1061149676'
 
     @pytest.fixture
     def instance(self, benzene, toluene):

--- a/gufe/tests/test_network.py
+++ b/gufe/tests/test_network.py
@@ -13,7 +13,7 @@ from .test_tokenization import GufeTokenizableTestsMixin
 class TestAlchemicalNetwork(GufeTokenizableTestsMixin):
 
     cls = AlchemicalNetwork
-    key = "AlchemicalNetwork-23f39cb7f2abd7845d34bcc23220dedb"
+    key = "AlchemicalNetwork-71e52000bd30c7e03857ec8f2abf0f66"
 
     @pytest.fixture
     def instance(self, benzene_variants_star_map):

--- a/gufe/tests/test_network.py
+++ b/gufe/tests/test_network.py
@@ -13,7 +13,7 @@ from .test_tokenization import GufeTokenizableTestsMixin
 class TestAlchemicalNetwork(GufeTokenizableTestsMixin):
 
     cls = AlchemicalNetwork
-    key = "AlchemicalNetwork-9c1d3f9ebc8e4d56d7347d59b0bda93c"
+    key = "AlchemicalNetwork-23f39cb7f2abd7845d34bcc23220dedb"
 
     @pytest.fixture
     def instance(self, benzene_variants_star_map):

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -83,13 +83,6 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin):
     def instance(self, named_ethane):
         return named_ethane
 
-    def test_rdkit_behavior(self, ethane, alt_ethane):
-        # Check that fixture setup is correct (we aren't accidentally
-        # testing tautologies)
-        assert ethane is not alt_ethane
-        assert ethane.to_rdkit() is not alt_ethane.to_rdkit()
-
-
     def test_error_missing_conformers(self):
         mol = Chem.MolFromSmiles("CC")
         with pytest.raises(ValueError, match="conformer"):

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -71,7 +71,7 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 class TestSmallMoleculeComponent(GufeTokenizableTestsMixin):
 
     cls = SmallMoleculeComponent
-    key = "SmallMoleculeComponent-49af192b1c49aec922f5c56a6194a9af"
+    key = "SmallMoleculeComponent-45d1c819e0b7c8a7179113e6296837fa"
 
     @pytest.fixture
     def instance(self, named_ethane):

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -15,7 +15,7 @@ else:
     HAS_OECHEM = oechem.OEChemIsLicensed()
 from gufe import SmallMoleculeComponent
 from gufe.components.explicitmoleculecomponent import (
-    _ensure_ofe_name, _ensure_ofe_version
+    _ensure_ofe_name,
 )
 import gufe
 import json
@@ -66,12 +66,6 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 
     assert out_name == expected
     assert rdkit.GetProp("ofe-name") == out_name
-
-
-def test_ensure_ofe_version():
-    rdkit = Chem.MolFromSmiles("CC")
-    _ensure_ofe_version(rdkit)
-    assert rdkit.GetProp("ofe-version") == gufe.__version__
 
 
 class TestSmallMoleculeComponent(GufeTokenizableTestsMixin):
@@ -140,19 +134,24 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin):
         assert named_ethane == deserialized
         assert serialized == reserialized
 
-    def test_to_sdf_string(self, named_ethane, serialization_template):
-        expected = serialization_template("ethane_template.sdf")
+    def test_to_sdf_string(self, named_ethane, ethane_sdf):
+        with open(ethane_sdf, "r") as f:
+            expected = f.read()
+
         assert named_ethane.to_sdf() == expected
 
     @pytest.mark.xfail
-    def test_from_sdf_string(self, named_ethane, serialization_template):
-        sdf_str = serialization_template("ethane_template.sdf")
+    def test_from_sdf_string(self, named_ethane, ethane_sdf):
+        with open(ethane_sdf, "r") as f:
+            sdf_str = f.read()
+
         assert SmallMoleculeComponent.from_sdf_string(sdf_str) == named_ethane
 
     @pytest.mark.xfail
-    def test_from_sdf_file(self, named_ethane, serialization_template,
+    def test_from_sdf_file(self, named_ethane, ethane_sdf,
                            tmpdir):
-        sdf_str = serialization_template("ethane_template.sdf")
+        with open(ethane_sdf, 'r') as f:
+            sdf_str = f.read()
         with open(tmpdir / "temp.sdf", mode='w') as tmpf:
             tmpf.write(sdf_str)
 

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -301,7 +301,6 @@ def test_prop_preservation(ethane, target, dtype):
     if dtype == 'int':
         assert obj.GetIntProp('foo') == 1234
     elif dtype == 'bool':
-        print(f'foo is {obj.GetProp("foo")}')
         assert obj.GetBoolProp('foo') is False
     elif dtype == 'str':
         assert obj.GetProp('foo') == 'bar'

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -71,7 +71,7 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 class TestSmallMoleculeComponent(GufeTokenizableTestsMixin):
 
     cls = SmallMoleculeComponent
-    key = "SmallMoleculeComponent-d8d7b85fcfa6d9a3859a1cc023c58b67"
+    key = "SmallMoleculeComponent-49af192b1c49aec922f5c56a6194a9af"
 
     @pytest.fixture
     def instance(self, named_ethane):

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -30,7 +30,7 @@ def complex_equilibrium(solvated_complex):
 class TestTransformation(GufeTokenizableTestsMixin):
 
     cls = Transformation
-    key = "Transformation-347b35a5eaae49e83d289a5ab86374bd"
+    key = "Transformation-dab3fd39d829ae3eebf381fb3e3f11fc"
 
     @pytest.fixture
     def instance(self, absolute_transformation):
@@ -109,7 +109,7 @@ class TestTransformation(GufeTokenizableTestsMixin):
 class TestNonTransformation(GufeTokenizableTestsMixin):
 
     cls = NonTransformation
-    key = "NonTransformation-bb37ab8f5d6cff772d3cf69e53dd2a94"
+    key = "NonTransformation-418abf6c353736783535c720abc2aa62"
 
     @pytest.fixture
     def instance(self, complex_equilibrium):

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -30,7 +30,7 @@ def complex_equilibrium(solvated_complex):
 class TestTransformation(GufeTokenizableTestsMixin):
 
     cls = Transformation
-    key = "Transformation-af747630b54613042022fdb183a27c14"
+    key = "Transformation-347b35a5eaae49e83d289a5ab86374bd"
 
     @pytest.fixture
     def instance(self, absolute_transformation):
@@ -109,7 +109,7 @@ class TestTransformation(GufeTokenizableTestsMixin):
 class TestNonTransformation(GufeTokenizableTestsMixin):
 
     cls = NonTransformation
-    key = "NonTransformation-d515c0765f4e8bde57bc586d10e29e56"
+    key = "NonTransformation-bb37ab8f5d6cff772d3cf69e53dd2a94"
 
     @pytest.fixture
     def instance(self, complex_equilibrium):

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -54,7 +54,9 @@ class _GufeTokenizableMeta(type):
     def __call__(cls, *args, **kwargs):
         instance = super().__call__(*args, **kwargs)
         # add to registry if not already present
-        TOKENIZABLE_REGISTRY.setdefault(instance.key, instance)
+        key = instance.key
+        TOKENIZABLE_REGISTRY.setdefault(key, instance)
+        instance = TOKENIZABLE_REGISTRY[key]
         return instance
 
 


### PR DESCRIPTION
This ensures that only one `GufeTokenizable` exists in memory for any given gufe key.

Consider this more a proposal than a request to merge.

Significant changed behavior:

* `tokenizable.copy_with_replacements()` (with no args) used to give a distinct copy in memory. It no longer does this, since no two different objects in memory can have the same gufe key.
* several tests in `SmallMoleculeComponent` are now meaningless -- there were a bunch of tests predicated on the idea that two molecules were equal but not the same in memory. This is now testing tautologies (I had put a test in to ensure that those tests were not testing tautologies; that extra test is now failing).
* removed concept of ofe-version from SMC
* serialise the `_rdkit` mol rather than going via openff.  this should preserve Props better

fixes  #145.

This would also require changing the docs on [deduplication in memory](https://gufe.readthedocs.io/en/latest/guide/serialization.html#deduplication-in-memory).