### PR TITLE
Make `shared` into an `ExternalStorage` object

### DIFF
--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -354,10 +354,11 @@ class ProtocolDAG(GufeTokenizable, DAGMixin):
         return cls(**dct)
 
 
-def execute_DAG(protocoldag: ProtocolDAG, *,
-                shared: Optional[ExternalStorage] = None,
-                raise_error: bool = True,
-                ) -> ProtocolDAGResult:
+def execute_DAG(
+    protocoldag: ProtocolDAG, *,
+    shared: Optional[Union[ExternalStorage, PathLike, str]] = None,
+    raise_error: bool = True,
+) -> ProtocolDAGResult:
     """Execute the full DAG in-serial, in process.
 
     This is intended for debug use for Protocol developers.
@@ -367,7 +368,7 @@ def execute_DAG(protocoldag: ProtocolDAG, *,
     ----------
     protocoldag : ProtocolDAG
         The `ProtocolDAG` to execute.
-    shared : Optiona[ExternalStorage]
+    shared : Optional[ExternalStorage]
        Storage space that persists across whole DAG execution, but may
        be removed after. Used by some `ProtocolUnit`s to pass file
        contents to dependent `ProtocolUnit` objects.
@@ -385,6 +386,9 @@ def execute_DAG(protocoldag: ProtocolDAG, *,
     """
     if shared is None:
         shared = FileStorage(os.getcwd())
+
+    if isinstance(shared, (PathLike, str)):
+        shared = FileStorage(shared)
 
     # iterate in DAG order
     results: dict[GufeKey, ProtocolUnitResult] = {}

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -319,6 +319,9 @@ class ProtocolUnit(GufeTokenizable):
                 traceback=traceback.format_exc()
             )
 
+        # extract any files from the values of the dict that _execute
+        # returns; ensure that we move these to shared so they can be used
+        # by later units
         output_files = [f for f in outputs.values() if isinstance(f, Path)]
         for path in output_files:
             # label is worth further consideration before merge
@@ -364,8 +367,9 @@ class ProtocolUnit(GufeTokenizable):
         chained together, with their outputs exposed to `ProtocolUnit`s
         dependent on them.
 
-        The return dict should contain objects that are either `gufe` objects
-        or JSON-serializables.
+        The return dict should contain objects that are `gufe` objects,
+        JSON-serializables, or pathlib.Path objects pointing to files that
+        should be moved to shared storage.
 
         """
         ...

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -322,11 +322,11 @@ class ProtocolUnit(GufeTokenizable):
         # extract any files from the values of the dict that _execute
         # returns; ensure that we move these to shared so they can be used
         # by later units
-        output_files = [f for f in outputs.values() if isinstance(f, Path)]
-        for path in output_files:
-            # label is worth further consideration before merge
-            label = str(self.key / path)
-            shared.store_path(label, path)
+        for label, path in outputs.items():
+            is_file = (isinstance(path, Path) and path.exists()
+                       and not path.is_dir())
+            if is_file:
+                shared.store_path(f"{self.key}/{label}", path)
 
         if scratch is None:
             scratch_tmp.cleanup()

--- a/gufe/storage/__init__.py
+++ b/gufe/storage/__init__.py
@@ -1,0 +1,2 @@
+from .externalresource.base import ExternalStorage
+from .externalresource.filestorage import FileStorage

--- a/gufe/storage/externalresource/filestorage.py
+++ b/gufe/storage/externalresource/filestorage.py
@@ -14,7 +14,7 @@ from ..errors import (
 
 # TODO: this should use pydantic to check init inputs
 class FileStorage(ExternalStorage):
-    def __init__(self, root_dir: Union[pathlib.Path, str]):
+    def __init__(self, root_dir: Union[os.PathLike, str]):
         self.root_dir = pathlib.Path(root_dir)
 
     def _exists(self, location):

--- a/gufe/storage/externalresource/filestorage.py
+++ b/gufe/storage/externalresource/filestorage.py
@@ -32,6 +32,9 @@ class FileStorage(ExternalStorage):
     def _store_path(self, location, path):
         my_path = self._as_path(location)
         if path.resolve() != my_path.resolve():
+            if not my_path.parent.exists():
+                my_path.parent.mkdir(parents=True)
+
             shutil.copyfile(path, my_path)
 
     def _iter_contents(self, prefix):

--- a/gufe/tests/storage/test_externalresource.py
+++ b/gufe/tests/storage/test_externalresource.py
@@ -52,20 +52,27 @@ class TestFileStorage:
         with open(fileloc, 'rb') as f:
             assert as_bytes == f.read()
 
-    def test_store_path(self, file_storage):
+    @pytest.mark.parametrize('missing_parent_dir', [True, False])
+    def test_store_path(self, file_storage, missing_parent_dir):
         orig_file = file_storage.root_dir / ".hidden" / "bar.txt"
         orig_file.parent.mkdir()
         as_bytes = "This is bar".encode('utf-8')
         with open(orig_file, 'wb') as f:
             f.write(as_bytes)
 
-        fileloc = file_storage.root_dir / "bar.txt"
-        assert not fileloc.exists()
+        if missing_parent_dir:
+            fileloc = "qux/bar.txt"
+        else:
+            fileloc = "bar.txt"
+
+        filename = file_storage.root_dir / fileloc
+
+        assert not filename.exists()
 
         file_storage.store_path(fileloc, orig_file)
 
-        assert fileloc.exists()
-        with open(fileloc, 'rb') as f:
+        assert filename.exists()
+        with open(filename, 'rb') as f:
             assert as_bytes == f.read()
 
     def test_delete(self, file_storage):

--- a/gufe/tests/test_protocol_unit.py
+++ b/gufe/tests/test_protocol_unit.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from gufe.protocols.protocolunit import ProtocolUnit, Context, ProtocolUnitFailure
 from gufe.tests.test_tokenization import GufeTokenizableTestsMixin
+from gufe.storage import FileStorage
 
 
 class DummyUnit(ProtocolUnit):
@@ -38,12 +39,13 @@ class TestProtocolUnit(GufeTokenizableTestsMixin):
 
     def test_execute(self, tmpdir):
         with tmpdir.as_cwd():
-            u: ProtocolUnitFailure = DummyUnit().execute(shared=Path('.'), an_input=3)
+            shared = FileStorage(".")
+            u: ProtocolUnitFailure = DummyUnit().execute(shared=shared, an_input=3)
             assert u.exception[0] == "ValueError"
 
             # now try actually letting the error raise on execute
             with pytest.raises(ValueError, match="should always be 2"):
-                DummyUnit().execute(shared=Path('.'), raise_error=True, an_input=3)
+                DummyUnit().execute(shared=shared, raise_error=True, an_input=3)
 
     def test_normalize(self, dummy_unit):
         thingy = dummy_unit.key


### PR DESCRIPTION
Resolves #120.

I'm not 100% sure that this is the right way to do it, but it is the best thing I've come up with. A couple major points:

1. As said in the title, this uses our existing `ExternalStorage` for `shared`. That API is probably bigger than we need (I think we only need `store_path` and `get_filename`), but we already have it in place.
2. This now takes all `pathlib.Path` outputs from the dict returned by `ProtocolUnit._execute` and ensures that they are saved to `shared`.
3. The label used in `shared.store_path` is worth discussion. We've previously decided that permanent storage does not use a labelling system in common with the protocol system, so I've opted for a very simple label here. The downside is that we'll need to copy files around a lot.

This is a significant API break. `ProtocoUnit`s that use files generated by other units will need to get the filename with `shared.get_filename(label)`.