### PR TITLE
Readonly settings

### DIFF
--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -112,7 +112,7 @@ class Protocol(GufeTokenizable):
 
     @classmethod
     @abc.abstractmethod
-    def _default_settings(cls) -> type[Settings]:
+    def _default_settings(cls) -> Settings:
         """Method to override in custom `Protocol` subclasses.
 
         Gives a usable instance of ``Settings`` that function as
@@ -122,7 +122,7 @@ class Protocol(GufeTokenizable):
         raise NotImplementedError()
 
     @classmethod
-    def default_settings(cls) -> type[Settings]:
+    def default_settings(cls) -> Settings:
         """Get the default settings for this `Protocol`.
 
         These can be modified and passed in as the `settings` for a new

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -103,7 +103,7 @@ class Protocol(GufeTokenizable):
         make_readonly(self._settings)
 
     @property
-    def settings(self) -> type[Settings]:
+    def settings(self) -> Settings:
         """The full settings for this ``Protocol`` instance.  This is read only"""
         return self._settings
 

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -92,12 +92,12 @@ class Protocol(GufeTokenizable):
             The full settings for this ``Protocol`` instance.  Must be passed an instance of Settings or a
             subclass which is specialised for a particular Protocol
         """
-        self._settings = settings.copy(deep=True)
+        self._settings = settings.frozen_copy()
 
     @property
     def settings(self) -> Settings:
         """A copy of the full settings for this ``Protocol`` instance.  This is read only"""
-        return self._settings.copy(deep=True)
+        return self._settings.frozen_copy()
 
     @classmethod
     def _defaults(cls):

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -96,8 +96,8 @@ class Protocol(GufeTokenizable):
 
     @property
     def settings(self) -> Settings:
-        """A copy of the full settings for this ``Protocol`` instance.  This is read only"""
-        return self._settings.frozen_copy()
+        """A read-only view of the settings for this ``Protocol`` instance."""
+        return self._settings
 
     @classmethod
     def _defaults(cls):

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -79,11 +79,11 @@ class Protocol(GufeTokenizable):
     - `_gather`
     - `_default_settings`
     """
-    _settings: type[Settings]
+    _settings: Settings
     result_cls: type[ProtocolResult]
     """Corresponding `ProtocolResult` subclass."""
 
-    def __init__(self, settings: type[Settings]):
+    def __init__(self, settings: Settings):
         """Create a new ``Protocol`` instance.
 
         Parameters

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -92,20 +92,12 @@ class Protocol(GufeTokenizable):
             The full settings for this ``Protocol`` instance.  Must be passed an instance of Settings or a
             subclass which is specialised for a particular Protocol
         """
-        self._settings = settings
-
-        def make_readonly(s):
-            # recursively make the Settings object, and all Settings contained within, readonly
-            s.__config__.allow_mutation = False
-            for fieldname, c in s:
-                if isinstance(c, SettingsBaseModel):
-                    make_readonly(c)
-        make_readonly(self._settings)
+        self._settings = settings.copy(deep=True)
 
     @property
     def settings(self) -> Settings:
-        """The full settings for this ``Protocol`` instance.  This is read only"""
-        return self._settings
+        """A copy of the full settings for this ``Protocol`` instance.  This is read only"""
+        return self._settings.copy(deep=True)
 
     @classmethod
     def _defaults(cls):

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -79,17 +79,18 @@ class Protocol(GufeTokenizable):
     - `_gather`
     - `_default_settings`
     """
-    _settings: Settings
+    _settings: type[Settings]
     result_cls: type[ProtocolResult]
     """Corresponding `ProtocolResult` subclass."""
 
-    def __init__(self, settings: Settings):
+    def __init__(self, settings: type[Settings]):
         """Create a new ``Protocol`` instance.
 
         Parameters
         ----------
         settings : Settings
-            The full settings for this ``Protocol`` instance.
+            The full settings for this ``Protocol`` instance.  Must be passed an instance of Settings or a
+            subclass which is specialised for a particular Protocol
         """
         self._settings = settings
 
@@ -111,7 +112,7 @@ class Protocol(GufeTokenizable):
 
     @classmethod
     @abc.abstractmethod
-    def _default_settings(cls) -> Settings:
+    def _default_settings(cls) -> type[Settings]:
         """Method to override in custom `Protocol` subclasses.
 
         Gives a usable instance of ``Settings`` that function as
@@ -121,7 +122,7 @@ class Protocol(GufeTokenizable):
         raise NotImplementedError()
 
     @classmethod
-    def default_settings(cls) -> Settings:
+    def default_settings(cls) -> type[Settings]:
         """Get the default settings for this `Protocol`.
 
         These can be modified and passed in as the `settings` for a new

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -94,7 +94,7 @@ class Protocol(GufeTokenizable):
         """
         self._settings = settings
 
-        def make_readonly(s: type[SettingsBaseModel]):
+        def make_readonly(s):
             # recursively make the Settings object, and all Settings contained within, readonly
             s.__config__.allow_mutation = False
             for fieldname, c in s:

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -9,7 +9,7 @@ import abc
 from typing import Optional, Iterable, Any, Union
 from openff.units import Quantity
 
-from ..settings import Settings
+from ..settings import Settings, SettingsBaseModel
 from ..tokenization import GufeTokenizable, GufeKey
 from ..chemicalsystem import ChemicalSystem
 from ..mapping import ComponentMapping
@@ -94,9 +94,17 @@ class Protocol(GufeTokenizable):
         """
         self._settings = settings
 
+        def make_readonly(s: type[SettingsBaseModel]):
+            # recursively make the Settings object, and all Settings contained within, readonly
+            s.__config__.allow_mutation = False
+            for fieldname, c in s:
+                if isinstance(c, SettingsBaseModel):
+                    make_readonly(c)
+        make_readonly(self._settings)
+
     @property
-    def settings(self) -> Settings:
-        """The full settings for this ``Protocol`` instance."""
+    def settings(self) -> type[Settings]:
+        """The full settings for this ``Protocol`` instance.  This is read only"""
         return self._settings
 
     @classmethod

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -58,7 +58,8 @@ class SettingsBaseModel(DefaultModel):
     def __setattr__(self, name, value):
         if self._is_frozen:
             raise TypeError(f"Cannot set '{name}': Settings are immutable "
-                            "once attached to a Protocol")
+                            "once attached to a Protocol and cannot be modified. "
+                            "Modify Settings *before* creating the Protocol.")
         return super().__setattr__(name, value)
 
 

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -16,6 +16,7 @@ try:
         Extra,
         Field,
         PositiveFloat,
+        PrivateAttr,
         validator,
     )
 except ImportError:
@@ -23,17 +24,54 @@ except ImportError:
         Extra,
         Field,
         PositiveFloat,
+        PrivateAttr,
         validator,
     )
 
 
 class SettingsBaseModel(DefaultModel):
     """Settings and modifications we want for all settings classes."""
+    _is_frozen: bool = PrivateAttr(default_factory=lambda: False)
 
     class Config:
         extra = Extra.forbid
         arbitrary_types_allowed = False
         smart_union = True
+
+    def frozen_copy(self):
+        copied = self.copy(deep=True)
+
+        def freeze_model(model):
+            submodels = (
+                mod for field in model.__fields__
+                if isinstance(mod := getattr(model, field), SettingsBaseModel)
+            )
+            for mod in submodels:
+                freeze_model(mod)
+
+            if not model._is_frozen:
+                model._is_frozen = True
+
+        freeze_model(copied)
+        return copied
+
+    def __setattr__(self, name, value):
+        if self._is_frozen:
+            raise TypeError(f"Cannot set '{name}': Settings are immutable "
+                            "once attached to a Protocol")
+
+        if name == "_is_frozen":
+            return object.__setattr__(self, '_is_frozen', value)
+
+        return super().__setattr__(name, value)
+
+    def __getattr__(self, name):
+        if name == "_is_frozen":
+            return object.__getattribute__(self, name)
+        else:
+            return super().__getattr__(name)
+
+
 
 
 class ThermoSettings(SettingsBaseModel):

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -59,19 +59,7 @@ class SettingsBaseModel(DefaultModel):
         if self._is_frozen:
             raise TypeError(f"Cannot set '{name}': Settings are immutable "
                             "once attached to a Protocol")
-
-        if name == "_is_frozen":
-            return object.__setattr__(self, '_is_frozen', value)
-
         return super().__setattr__(name, value)
-
-    def __getattr__(self, name):
-        if name == "_is_frozen":
-            return object.__getattribute__(self, name)
-        else:
-            return super().__getattr__(name)
-
-
 
 
 class ThermoSettings(SettingsBaseModel):

--- a/gufe/tests/conftest.py
+++ b/gufe/tests/conftest.py
@@ -244,7 +244,7 @@ def absolute_transformation(solvated_ligand, solvated_complex):
     return gufe.Transformation(
         solvated_ligand,
         solvated_complex,
-        protocol=DummyProtocol(settings=None),
+        protocol=DummyProtocol(settings=DummyProtocol.default_settings()),
         mapping=None,
     )
 
@@ -253,7 +253,7 @@ def absolute_transformation(solvated_ligand, solvated_complex):
 def complex_equilibrium(solvated_complex):
     return gufe.NonTransformation(
         solvated_complex,
-        protocol=DummyProtocol(settings=None)
+        protocol=DummyProtocol(settings=DummyProtocol.default_settings())
     )
 
 
@@ -292,7 +292,7 @@ def benzene_variants_star_map(
         ] = gufe.Transformation(
             solvated_ligands["benzene"],
             solvated_ligands[ligand.name],
-            protocol=DummyProtocol(settings=None),
+            protocol=DummyProtocol(settings=DummyProtocol.default_settings()),
             mapping=None,
         )
 
@@ -316,7 +316,7 @@ def benzene_variants_star_map(
         ] = gufe.Transformation(
             solvated_complexes["benzene"],
             solvated_complexes[ligand.name],
-            protocol=DummyProtocol(settings=None),
+            protocol=DummyProtocol(settings=DummyProtocol.default_settings()),
             mapping=None,
         )
 

--- a/gufe/tests/test_alchemicalnetwork.py
+++ b/gufe/tests/test_alchemicalnetwork.py
@@ -13,8 +13,8 @@ from .test_tokenization import GufeTokenizableTestsMixin
 class TestAlchemicalNetwork(GufeTokenizableTestsMixin):
 
     cls = AlchemicalNetwork
-    key = "AlchemicalNetwork-44993b48101debfff70e360627487a5b"
-    repr = "<AlchemicalNetwork-44993b48101debfff70e360627487a5b>"
+    key = "AlchemicalNetwork-d1035e11493ca60ff7bac5171eddfee3"
+    repr = "<AlchemicalNetwork-d1035e11493ca60ff7bac5171eddfee3>"
 
     @pytest.fixture
     def instance(self, benzene_variants_star_map):

--- a/gufe/tests/test_alchemicalnetwork.py
+++ b/gufe/tests/test_alchemicalnetwork.py
@@ -13,8 +13,8 @@ from .test_tokenization import GufeTokenizableTestsMixin
 class TestAlchemicalNetwork(GufeTokenizableTestsMixin):
 
     cls = AlchemicalNetwork
-    key = "AlchemicalNetwork-8c6df17d7ecf5902e2e338984cc11140"
-    repr = "<AlchemicalNetwork-8c6df17d7ecf5902e2e338984cc11140>"
+    key = "AlchemicalNetwork-44993b48101debfff70e360627487a5b"
+    repr = "<AlchemicalNetwork-44993b48101debfff70e360627487a5b>"
 
     @pytest.fixture
     def instance(self, benzene_variants_star_map):

--- a/gufe/tests/test_models.py
+++ b/gufe/tests/test_models.py
@@ -53,3 +53,45 @@ def test_invalid_constraint(value, good):
     else:
         with pytest.raises(ValueError):
             _ = OpenMMSystemGeneratorFFSettings(constraints=value)
+
+
+class TestFreezing:
+    def test_default_not_frozen(self):
+        s = Settings.get_defaults()
+        # make a frozen copy to check this doesn't alter the original
+        s2 = s.frozen_copy()
+
+        s.thermo_settings.temperature = 199 * unit.kelvin
+        assert s.thermo_settings.temperature == 199 * unit.kelvin
+
+    def test_freezing(self):
+        s = Settings.get_defaults()
+
+        s2 = s.frozen_copy()
+
+        with pytest.raises(AttributeError, match="immutable"):
+            s2.thermo_settings.temperature = 199 * unit.kelvin
+
+    def test_unfreezing(self):
+        s = Settings.get_defaults()
+
+        s2 = s.frozen_copy()
+
+        with pytest.raises(AttributeError, match="immutable"):
+            s2.thermo_settings.temperature = 199 * unit.kelvin
+
+        assert s2.is_frozen
+
+        s3 = s2.unfrozen_copy()
+
+        s3.thermo_settings.temperature = 199 * unit.kelvin
+        assert s3.thermo_settings.temperature == 199 * unit.kelvin
+
+    def test_frozen_equality(self):
+        # the frozen-ness of Settings doesn't alter its contents
+        # therefore a frozen/unfrozen Settings which are otherwise identical
+        # should be considered equal
+        s = Settings.get_defaults()
+        s2 = s.frozen_copy()
+
+        assert s == s2

--- a/gufe/tests/test_models.py
+++ b/gufe/tests/test_models.py
@@ -9,7 +9,11 @@ import json
 from openff.units import unit
 import pytest
 
-from gufe.settings.models import Settings, OpenMMSystemGeneratorFFSettings
+from gufe.settings.models import (
+    OpenMMSystemGeneratorFFSettings,
+    Settings,
+    ThermoSettings,
+)
 
 
 def test_model_schema():
@@ -95,3 +99,15 @@ class TestFreezing:
         s2 = s.frozen_copy()
 
         assert s == s2
+
+    def test_set_subsection(self):
+        # check that attempting to set a subsection of settings still respects
+        # frozen state of parent object
+        s = Settings.get_defaults().frozen_copy()
+
+        assert s.is_frozen
+
+        ts = ThermoSettings(temperature=301 * unit.kelvin)
+
+        with pytest.raises(AttributeError, match="immutable"):
+            s.thermo_settings = ts

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -722,11 +722,15 @@ def test_execute_DAG_bad_nretries(solvated_ligand, vacuum_ligand, tmpdir):
 
 
 def test_settings_readonly():
-    # checks that settings are immutable once inside a Protocol
+    # checks that settings aren't editable once inside a Protocol
     p = DummyProtocol(DummyProtocol.default_settings())
 
-    with pytest.raises(TypeError, match="immutable"):
-        p.settings.n_repeats = 72
-    # check that child settings are also immutable
-    with pytest.raises(TypeError, match="immutable"):
-        p.settings.thermo_settings.temperature = 10.0 * unit.kelvin
+    before = p.settings.n_repeats
+
+    p.settings.n_repeats = before + 1
+    assert p.settings.n_repeats == before
+
+    # also check child settings
+    before = p.settings.thermo_settings.temperature
+    p.settings.thermo_settings.temperature = 400.0 * unit.kelvin
+    assert p.settings.thermo_settings.temperature == before

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -727,10 +727,15 @@ def test_settings_readonly():
 
     before = p.settings.n_repeats
 
-    p.settings.n_repeats = before + 1
+    with pytest.raises(TypeError, match="immutable"):
+        p.settings.n_repeats = before + 1
+
     assert p.settings.n_repeats == before
 
     # also check child settings
     before = p.settings.thermo_settings.temperature
-    p.settings.thermo_settings.temperature = 400.0 * unit.kelvin
+
+    with pytest.raises(TypeError, match="immutable"):
+        p.settings.thermo_settings.temperature = 400.0 * unit.kelvin
+
     assert p.settings.thermo_settings.temperature == before

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -719,3 +719,14 @@ def test_execute_DAG_bad_nretries(solvated_ligand, vacuum_ligand, tmpdir):
                             keep_scratch=True,
                             raise_error=False,
                             n_retries=-1)
+
+
+def test_settings_readonly():
+    # checks that settings are immutable once inside a Protocol
+    p = DummyProtocol(DummyProtocol.default_settings())
+
+    with pytest.raises(TypeError, match="immutable"):
+        p.settings.n_repeats = 72
+    # check that child settings are also immutable
+    with pytest.raises(TypeError, match="immutable"):
+        p.settings.thermo_settings.temperature = 10.0 * unit.kelvin

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -727,7 +727,7 @@ def test_settings_readonly():
 
     before = p.settings.n_repeats
 
-    with pytest.raises(TypeError, match="immutable"):
+    with pytest.raises(AttributeError, match="immutable"):
         p.settings.n_repeats = before + 1
 
     assert p.settings.n_repeats == before
@@ -735,7 +735,7 @@ def test_settings_readonly():
     # also check child settings
     before = p.settings.thermo_settings.temperature
 
-    with pytest.raises(TypeError, match="immutable"):
+    with pytest.raises(AttributeError, match="immutable"):
         p.settings.thermo_settings.temperature = 400.0 * unit.kelvin
 
     assert p.settings.thermo_settings.temperature == before

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -306,7 +306,7 @@ class TestProtocol(GufeTokenizableTestsMixin):
         assert len(succeeded_units) > 0
 
     def test_dag_execute_failure_raise_error(self, solvated_ligand, vacuum_ligand, tmpdir):
-        protocol = BrokenProtocol(settings=None)
+        protocol = BrokenProtocol(settings=BrokenProtocol.default_settings())
         dag = protocol.create(
             stateA=solvated_ligand, stateB=vacuum_ligand, name="a broken dummy run",
             mapping=None,
@@ -507,7 +507,7 @@ class NoDepsProtocol(Protocol):
 
     @classmethod
     def _default_settings(cls):
-        return {}
+        return settings.Settings.get_defaults()
 
     def _create(
             self,

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -100,10 +100,12 @@ class TestTransformation(GufeTokenizableTestsMixin):
         )
         assert absolute_transformation != opposite
 
+        s = DummyProtocol.default_settings()
+        s.n_repeats = 99
         different_protocol_settings = Transformation(
             solvated_ligand,
             solvated_complex,
-            protocol=DummyProtocol(settings={"lol": True}),
+            protocol=DummyProtocol(settings=s),
         )
         assert absolute_transformation != different_protocol_settings
 

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -190,9 +190,10 @@ class TestNonTransformation(GufeTokenizableTestsMixin):
         assert len(protocolresult.data) == 2
 
     def test_equality(self, complex_equilibrium, solvated_ligand, solvated_complex):
-
+        s = DummyProtocol.default_settings()
+        s.n_repeats = 4031
         different_protocol_settings = NonTransformation(
-            solvated_complex, protocol=DummyProtocol(settings={"lol": True})
+            solvated_complex, protocol=DummyProtocol(settings=s)
         )
         assert complex_equilibrium != different_protocol_settings
 


### PR DESCRIPTION
Adds `Settings.frozen_copy` and `Settings.unfrozen_copy` to create immutable/mutable versions of Settings object.  These freezes are recursive and apply to all contained Settings too.

Protocols now freeze their Settings on creation.  This should stop mistakes around modifying a Protocol's Settings in place.