### PR TITLE
Docs cleanup

### DIFF
--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -18,14 +18,14 @@ class ChemicalSystem(GufeTokenizable, abc.Mapping):
     components
         The molecular representation of the chemical state, including
         connectivity and coordinates. This is a frozendict with user-defined
-        labels as keys, `Component`s as values.
+        labels as keys, :class:`.Component`\ s as values.
     box_vectors
         Numpy array indicating shape and size of unit cell for the system. May
         be a partial definition to allow for variability on certain dimensions.
     name
         Optional identifier for the chemical state; used as part of the
         (hashable) graph node itself when the chemical state is added to an
-        `AlchemicalNetwork`.
+        :class:`.AlchemicalNetwork`.
 
     """
 
@@ -42,15 +42,15 @@ class ChemicalSystem(GufeTokenizable, abc.Mapping):
         components
             The molecular representation of the chemical state, including
             connectivity and coordinates. Given as a dict with user-defined
-            labels as keys, `Component`s as values.
+            labels as keys, :class:`.Component`\ s as values.
         box_vectors
-            Optional `numpy` array indicating shape and size of unit cell for
+            Optional ``numpy`` array indicating shape and size of unit cell for
             the system. May be a partial definition to allow for variability on
             certain dimensions.
         name
             Optional identifier for the chemical state; included with the other
             attributes as part of the (hashable) graph node itself when the
-            chemical state is added to an `AlchemicalNetwork`.
+            chemical state is added to an :class:`.AlchemicalNetwork`.
 
         """
         super().__init__()

--- a/gufe/network.py
+++ b/gufe/network.py
@@ -11,14 +11,19 @@ from .transformations import Transformation
 
 
 class AlchemicalNetwork(GufeTokenizable):
-    """A network of `ChemicalSystem`s as nodes, `Transformation`s as edges.
+    """A network with all the information needed for a simulation campaign.
+
+    Nodes are :class:`.ChemicalSystem`\ s and edges are
+    ;class:`.Transformation`\ s.
 
     Attributes
     ----------
     edges : FrozenSet[Transformation]
-        The edges of the network, given as a `frozenset` of `Transformation`s.
+        The edges of the network, given as a ``frozenset`` of
+        :class:`.Transformation`\ s.
     nodes : FrozenSet[ChemicalSystem]
-        The nodes of the network, given as a `frozenset` of `ChemicalSystem`s.
+        The nodes of the network, given as a ``frozenset`` of
+        :class:`.ChemicalSystem` \ s.
     name : Optional identifier for the network.
 
     """

--- a/gufe/network.py
+++ b/gufe/network.py
@@ -14,7 +14,7 @@ class AlchemicalNetwork(GufeTokenizable):
     """A network with all the information needed for a simulation campaign.
 
     Nodes are :class:`.ChemicalSystem`\ s and edges are
-    ;class:`.Transformation`\ s.
+    :class:`.Transformation`\ s.
 
     Attributes
     ----------

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -15,14 +15,14 @@ from ..mapping import ComponentMapping
 class Transformation(GufeTokenizable):
     """An edge of an alchemical network.
 
-    Connects two `ChemicalSystem`s, with directionality.
+    Connects two :class:`.ChemicalSystem`\ s, with directionality.
 
     Attributes
     ----------
     stateA : ChemicalSystem
-        The starting `ChemicalSystem` for the transformation.
+        The starting :class:`.ChemicalSystem` for the transformation.
     stateB : ChemicalSystem
-        The ending `ChemicalSystem` for the transformation.
+        The ending :class:`.ChemicalSystem` for the transformation.
     protocol : Protocol
         The protocol used to perform the transformation.
         Includes all details needed to perform required
@@ -30,11 +30,11 @@ class Transformation(GufeTokenizable):
         May also correspond to an experimental result.
     mapping : Optional[Dict[str, ComponentMapping]]
         Mapping of e.g. atoms between the `stateA` and `stateB`
-        `ChemicalSystem`s.
+        :class:`.ChemicalSystem`\ s.
     name : Optional[str]
         Optional identifier for the transformation; set this to a unique value
         if adding multiple, otherwise identical transformations to the same
-        `AlchemicalNetwork` to avoid deduplication
+        :class:`.AlchemicalNetwork` to avoid deduplication
 
     """
 


### PR DESCRIPTION
This does a little cleanup, mainly things that fix up RST (missing escape to fix plurals; lack of roles defined).

This will fix some issues in openfreeenergy/openfe#325.