### PR TITLE
Improved readonly settings

### DIFF
--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -103,12 +103,12 @@ class Protocol(GufeTokenizable):
             The full settings for this ``Protocol`` instance.  Must be passed an instance of Settings or a
             subclass which is specialised for a particular Protocol
         """
-        self._settings = settings.copy(deep=True)
+        self._settings = settings.frozen_copy()
 
     @property
     def settings(self) -> Settings:
         """A copy of the full settings for this ``Protocol`` instance.  This is read only"""
-        return self._settings.copy(deep=True)
+        return self._settings.frozen_copy()
 
     @classmethod
     def _defaults(cls):

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -44,7 +44,8 @@ class SettingsBaseModel(DefaultModel):
     def __setattr__(self, name, value):
         if self._is_frozen:
             raise TypeError(f"Cannot set '{name}': Settings are immutable "
-                            "once attached to a Protocol")
+                            "once attached to a Protocol and cannot be modified. "
+                            "Modify Settings *before* creating the Protocol.")
         return super().__setattr__(name, value)
 
 

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -45,19 +45,7 @@ class SettingsBaseModel(DefaultModel):
         if self._is_frozen:
             raise TypeError(f"Cannot set '{name}': Settings are immutable "
                             "once attached to a Protocol")
-
-        if name == "_is_frozen":
-            return object.__setattr__(self, '_is_frozen', value)
-
         return super().__setattr__(name, value)
-
-    def __getattr__(self, name):
-        if name == "_is_frozen":
-            return object.__getattribute__(self, name)
-        else:
-            return super().__getattr__(name)
-
-
 
 
 class ThermoSettings(SettingsBaseModel):

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -676,10 +676,15 @@ def test_settings_readonly():
 
     before = p.settings.n_repeats
 
-    p.settings.n_repeats = before + 1
+    with pytest.raises(TypeError, match="immutable"):
+        p.settings.n_repeats = before + 1
+
     assert p.settings.n_repeats == before
 
     # also check child settings
     before = p.settings.thermo_settings.temperature
-    p.settings.thermo_settings.temperature = 400.0 * unit.kelvin
+
+    with pytest.raises(TypeError, match="immutable"):
+        p.settings.thermo_settings.temperature = 400.0 * unit.kelvin
+
     assert p.settings.thermo_settings.temperature == before


### PR DESCRIPTION
PR into the changes already in #169; @richardjgowers's readonly settings. Now raises `TypeError` if you try to mutate after settings get attached to a protocol.

Might be nice for something with more pydantic experience than me to look this over? But tests pass locally, at least.