### PR TITLE
LigandNetwork.to_*_alchemical_network

### DIFF
--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -224,7 +224,8 @@ class LigandNetwork(GufeTokenizable):
                 sysA = sys_from_dict(edge.componentA)
                 sysB = sys_from_dict(edge.componentB)
                 if autoname:
-                    name = f"{autoname_prefix}_{sysA.name}_{sysB.name}"
+                    prefix = f"{autoname_prefix}_" if autoname_prefix else ""
+                    name = f"{prefix}{sysA.name}_{sysB.name}"
                 else:
                     name = ""
 

--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -213,12 +213,17 @@ class LigandNetwork(GufeTokenizable):
 
                 # define a helper func to avoid repeated code
                 def sys_from_dict(component):
+                    """
+                    Input component alchemically changing. Other info taken
+                    from the outer scope.
+                    """
                     syscomps = {alchemical_label: component}
+                    other_labels = set(labels) - {alchemical_label}
                     syscomps.update({label: components[label]
-                                     for label in labels})
+                                     for label in other_labels})
 
                     if autoname:
-                        name = f"{sys[alchemical_label].name}_{leg_name}"
+                        name = f"{component.name}_{leg_name}"
                     else:
                         name = ""
 
@@ -275,7 +280,8 @@ class LigandNetwork(GufeTokenizable):
         }
         leg_labels = {
             "solvent": ["ligand", "solvent"],
-            "complex": ["ligand"] + list(other_components),
+            "complex": (["ligand", "solvent", "protein"]
+                        + list(other_components)),
         }
         return self._to_rfe_alchemical_network(
             components=components,
@@ -287,14 +293,15 @@ class LigandNetwork(GufeTokenizable):
 
     def to_rhfe_alchemical_network(self, *, solvent, protocol,
                                    autoname=True,
-                                   autoname_prefix="easy_rhfe"):
+                                   autoname_prefix="easy_rhfe",
+                                   **other_components):
         leg_labels = {
-            "solvent": ["ligand", "solvent"],
-            "vacuum": ["ligand"]
+            "solvent": ["ligand", "solvent"] + list(other_components),
+            "vacuum": ["ligand"] + list(other_components),
         }
         return self._to_rfe_alchemical_network(
-            components={"solvent": solvent},
-            leg_lables=leg_lables,
+            components={"solvent": solvent, **other_components},
+            leg_labels=leg_labels,
             protocol=protocol,
             autoname=autoname,
             autoname_prefix=autoname_prefix

--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -291,21 +291,23 @@ class LigandNetwork(GufeTokenizable):
             autoname_prefix=autoname_prefix
         )
 
-    def to_rhfe_alchemical_network(self, *, solvent, protocol,
-                                   autoname=True,
-                                   autoname_prefix="easy_rhfe",
-                                   **other_components):
-        leg_labels = {
-            "solvent": ["ligand", "solvent"] + list(other_components),
-            "vacuum": ["ligand"] + list(other_components),
-        }
-        return self._to_rfe_alchemical_network(
-            components={"solvent": solvent, **other_components},
-            leg_labels=leg_labels,
-            protocol=protocol,
-            autoname=autoname,
-            autoname_prefix=autoname_prefix
-        )
+    # on hold until we figure out how to best hack in the PME/NoCutoff
+    # switch
+    # def to_rhfe_alchemical_network(self, *, solvent, protocol,
+    #                                autoname=True,
+    #                                autoname_prefix="easy_rhfe",
+    #                                **other_components):
+    #     leg_labels = {
+    #         "solvent": ["ligand", "solvent"] + list(other_components),
+    #         "vacuum": ["ligand"] + list(other_components),
+    #     }
+    #     return self._to_rfe_alchemical_network(
+    #         components={"solvent": solvent, **other_components},
+    #         leg_labels=leg_labels,
+    #         protocol=protocol,
+    #         autoname=autoname,
+    #         autoname_prefix=autoname_prefix
+    #     )
 
     def is_connected(self) -> bool:
         """Are all ligands in the network (indirectly) connected to each other

--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -6,6 +6,7 @@ from itertools import chain
 import json
 import networkx as nx
 from typing import FrozenSet, Iterable, Optional
+import gufe
 
 from gufe import SmallMoleculeComponent
 from .mapping import LigandAtomMapping
@@ -186,7 +187,7 @@ class LigandNetwork(GufeTokenizable):
         leg_labels: dict[str, list[str]],
         protocol: gufe.Protocol,
         *,
-        alchemical_label="ligand",
+        alchemical_label: str = "ligand",
         autoname=True,
         autoname_prefix=""
     ) -> gufe.AlchemicalNetwork:
@@ -202,6 +203,9 @@ class LigandNetwork(GufeTokenizable):
             as used in the ``componentns`` dict.
         protocol: :class:`.Protocol`
             the protocol to apply
+        alchemical_label: str
+            the label for the component undergoing an alchemical
+            transformation (default ``'ligand'``)
         """
         transformations = []
         for edge in self.edges:
@@ -229,10 +233,12 @@ class LigandNetwork(GufeTokenizable):
                 else:
                     name = ""
 
-                mapping = {alchemical_label: edge.mapping}
+                mapping: dict[str, gufe.ComponentMapping] = {
+                    alchemical_label: edge,
+                }
 
-                transformation = Transformation(sysA, sysB, protocol,
-                                                mapping, name)
+                transformation = gufe.Transformation(sysA, sysB, protocol,
+                                                     mapping, name)
 
                 transformations.append(transformation)
 
@@ -269,7 +275,7 @@ class LigandNetwork(GufeTokenizable):
         }
         leg_labels = {
             "solvent": ["ligand", "solvent"],
-            "complex": ["ligand"] + list(shared_components),
+            "complex": ["ligand"] + list(other_components),
         }
         return self._to_rfe_alchemical_network(
             components=components,

--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -205,9 +205,9 @@ class LigandNetwork(GufeTokenizable):
         """
         transformations = []
         for edge in self.edges:
-            for leg_name, labels in leg_lables.items():
+            for leg_name, labels in leg_labels.items():
 
-                # define a couple helper funcs to avoid repeated code
+                # define a helper func to avoid repeated code
                 def sys_from_dict(component):
                     syscomps = {alchemical_label: component}
                     syscomps.update({label: components[label]

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -267,6 +267,12 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
     def test_is_not_connected(self, singleton_node_network):
         assert not singleton_node_network.network.is_connected()
 
+    def test_to_rbfe_network(self):
+        pytest.skip()
+
+    def test_to_rhfe_network(self):
+        pytest.skip()
+
 
 def test_empty_ligand_network(mols):
     # issue #217

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -284,7 +284,6 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
     def test_is_not_connected(self, singleton_node_network):
         assert not singleton_node_network.network.is_connected()
 
-    def test_to_rbfe_network(self):
     @pytest.mark.parametrize('with_cofactor', [True, False])
     def test_to_rbfe_alchemical_network(
         self,
@@ -346,7 +345,6 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
 
             assert list(edge.mapping) == ['ligand']
             assert edge.mapping['ligand'] in real_molecules_network.edges
-
 
     def test_to_rbfe_alchemical_network_autoname_false(
         self,

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -357,6 +357,7 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
         pytest.skip()
 
 
+    @pytest.mark.xfail  # method removed and on hold for now
     def test_to_rhfe_alchemical_network(self, real_molecules_network,
                                         solv_comp):
 

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -348,14 +348,44 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
             assert edge.mapping['ligand'] in real_molecules_network.edges
 
 
-    def test_to_rbfe_alchemical_network_autoname(
+    def test_to_rbfe_alchemical_network_autoname_false(
         self,
         real_molecules_network,
         prot_comp,
         solv_comp
     ):
-        pytest.skip()
+        rbfe = real_molecules_network.to_rbfe_alchemical_network(
+            solvent=solv_comp,
+            protein=prot_comp,
+            protocol=DummyProtocol(DummyProtocol.default_settings()),
+            autoname=False,
+        )
+        for edge in rbfe.edges:
+            assert edge.name == ""
+            for sys in [edge.stateA, edge.stateB]:
+                assert sys.name == ""
 
+    def test_to_rbfe_alchemical_network_autoname_true(
+        self,
+        real_molecules_network,
+        prot_comp,
+        solv_comp
+    ):
+        rbfe = real_molecules_network.to_rbfe_alchemical_network(
+            solvent=solv_comp,
+            protein=prot_comp,
+            protocol=DummyProtocol(DummyProtocol.default_settings()),
+            autoname=True,
+            autoname_prefix="",
+        )
+        expected_names = {
+            'benzene_complex_toluene_complex',
+            'benzene_solvent_toluene_solvent',
+            'benzene_complex_phenol_complex',
+            'benzene_solvent_phenol_solvent',
+        }
+        names = set(edge.name for edge in rbfe.edges)
+        assert names == expected_names
 
     @pytest.mark.xfail  # method removed and on hold for now
     def test_to_rhfe_alchemical_network(self, real_molecules_network,

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -3,6 +3,8 @@
 from typing import Iterable, NamedTuple
 import pytest
 import importlib.resources
+import gufe
+from gufe.tests.test_protocol import DummyProtocol
 from gufe import SmallMoleculeComponent, LigandNetwork, LigandAtomMapping
 
 from rdkit import Chem
@@ -17,7 +19,6 @@ def mol_from_smiles(smi):
     m.Compute2DCoords()
 
     return m
-
 
 class _NetworkTestContainer(NamedTuple):
     """Container to facilitate network testing"""
@@ -93,6 +94,22 @@ def singleton_node_network(mols, std_edges):
         n_edges=3,
     )
 
+@pytest.fixture
+def real_molecules_network(benzene, phenol, toluene):
+    """Small network with full mappings"""
+    # benzene to phenol
+    bp_mapping = {i: i for i in range(10)}
+    bp_mapping.update({10: 12, 11:11})
+
+    # benzene to toluene
+    bt_mapping = {i: i + 4 for i in range(10)}
+    bt_mapping.update({10: 2, 11: 14})
+
+    network = gufe.LigandNetwork([
+        gufe.LigandAtomMapping(benzene, toluene, bt_mapping),
+        gufe.LigandAtomMapping(benzene, phenol, bp_mapping),
+    ])
+    return network
 
 @pytest.fixture(params=['simple', 'doubled_edge', 'singleton_node'])
 def network_container(
@@ -268,10 +285,124 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
         assert not singleton_node_network.network.is_connected()
 
     def test_to_rbfe_network(self):
+    @pytest.mark.parametrize('with_cofactor', [True, False])
+    def test_to_rbfe_alchemical_network(
+        self,
+        real_molecules_network,
+        prot_comp,
+        solv_comp,
+        request,
+        with_cofactor,
+    ):
+        # obviously, this particular set of ligands with this particular
+        # protein makes no sense, but we should still be able to set it up
+        if with_cofactor:
+            others = {'cofactor': request.getfixturevalue('styrene')}
+        else:
+            others = {}
+
+        protocol = DummyProtocol(DummyProtocol.default_settings())
+        rbfe = real_molecules_network.to_rbfe_alchemical_network(
+            solvent=solv_comp,
+            protein=prot_comp,
+            protocol=protocol,
+            **others
+        )
+
+        expected_names = {
+            'easy_rbfe_benzene_solvent_toluene_solvent',
+            'easy_rbfe_benzene_complex_toluene_complex',
+            'easy_rbfe_benzene_solvent_phenol_solvent',
+            'easy_rbfe_benzene_complex_phenol_complex',
+        }
+        names = set(edge.name for edge in rbfe.edges)
+        assert names == expected_names
+
+        assert len(rbfe.edges) == 2 * len(real_molecules_network.edges)
+        for edge in rbfe.edges:
+            assert edge.protocol == protocol
+
+            compsA = edge.stateA.components
+            compsB = edge.stateB.components
+            if 'solvent' in edge.name:
+                labels = {'solvent', 'ligand'}
+            elif 'complex' in edge.name:
+                labels = {'solvent', 'ligand', 'protein'}
+                if with_cofactor:
+                    labels.add('cofactor')
+            else:  # -no-cov-
+                raise RuntimeError("Something went weird in testing. Unable "
+                                   f"to get leg for edge {edge}")
+
+            assert set(compsA) == labels
+            assert set(compsB) == labels
+
+            assert compsA['ligand'] != compsB['ligand']
+            assert compsA['ligand'].name == 'benzene'
+            assert compsA['solvent'] == compsB['solvent']
+            # for things that might not always exist, use .get
+            assert compsA.get('protein') == compsB.get('protein')
+            assert compsA.get('cofactor') == compsB.get('cofactor')
+
+            assert list(edge.mapping) == ['ligand']
+            assert edge.mapping['ligand'] in real_molecules_network.edges
+
+
+    def test_to_rbfe_alchemical_network_autoname(
+        self,
+        real_molecules_network,
+        prot_comp,
+        solv_comp
+    ):
         pytest.skip()
 
-    def test_to_rhfe_network(self):
-        pytest.skip()
+
+    def test_to_rhfe_alchemical_network(self, real_molecules_network,
+                                        solv_comp):
+
+        others = {}
+        protocol = DummyProtocol(DummyProtocol.default_settings())
+        rhfe = real_molecules_network.to_rhfe_alchemical_network(
+            solvent=solv_comp,
+            protocol=protocol,
+            **others
+        )
+
+        expected_names = {
+            'easy_rhfe_benzene_vacuum_toluene_vacuum',
+            'easy_rhfe_benzene_solvent_toluene_solvent',
+            'easy_rhfe_benzene_vacuum_phenol_vacuum',
+            'easy_rhfe_benzene_solvent_phenol_solvent',
+        }
+        names = set(edge.name for edge in rhfe.edges)
+        assert names == expected_names
+
+        assert len(rhfe.edges) == 2 * len(real_molecules_network.edges)
+        for edge in rhfe.edges:
+            assert edge.protocol == protocol
+
+            compsA = edge.stateA.components
+            compsB = edge.stateB.components
+
+            if 'vacuum' in edge.name:
+                labels = {'ligand'}
+            elif 'solvent' in edge.name:
+                labels = {'ligand', 'solvent'}
+            else:  # -no-cov-
+                raise RuntimeError("Something went weird in testing. Unable "
+                                   f"to get leg for edge {edge}")
+
+            labels |= set(others)
+
+            assert set(compsA) == labels
+            assert set(compsB) == labels
+
+            assert compsA['ligand'] != compsB['ligand']
+            assert compsA['ligand'].name == 'benzene'
+            assert compsA.get('solvent') == compsB.get('solvent')
+
+            assert list(edge.mapping) == ['ligand']
+            assert edge.mapping['ligand'] in real_molecules_network.edges
 
 
 def test_empty_ligand_network(mols):


### PR DESCRIPTION
@richardjgowers asked for a method on `LigandNetwork` to attach the protocol. This effectively moves some of the easy-planner stuff into gufe, but this aspect of it is likely to be broadly useful.

So far, a first glance of what I see the API looking like. Rough code, completely untested. Please take a look and see if this is the direction I should continue!