### PR TITLE
Always raise, don't swallow exception, if exception is `KeyboardInterrupt` in `ProtocolUnit.execute`

### DIFF
--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -322,6 +322,9 @@ class ProtocolUnit(GufeTokenizable):
                 start_time=start, end_time=datetime.datetime.now(),
             )
 
+        except KeyboardInterrupt:
+            # if we "fail" due to a KeyboardInterrupt, we always want to raise
+            raise
         except Exception as e:
             if raise_error:
                 raise


### PR DESCRIPTION
This PR is an attempt to address openforcefield/alchemiscale#132.

@mikemhenry raised a good point that for the case of a `KeyboardInterrupt`, even if `raise_error = False` for `ProtocolUnit.execute`, we probably always want to raise.

Is there any downside to this?
