### PR TITLE
Prevent `_GufeTozenizableMeta.__call__` from overwriting signature of `__init__`

### DIFF
--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -150,7 +150,6 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
     def __hash__(self):
         return hash(self.key)
 
-
     def _gufe_tokenize(self):
         """Return a list of normalized inputs for `gufe.base.tokenize`.
 

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -61,6 +61,24 @@ class _GufeTokenizableMeta(type):
         instance = TOKENIZABLE_REGISTRY[key]
         return instance
 
+    def __init__(cls, clsname, bases, attrs):
+        """
+        Restore the signature of __init__ or __new__
+        """
+        if inspect.signature(cls.__new__) != inspect.signature(object.__new__):
+            sig = inspect.signature(cls.__new__)
+        elif inspect.signature(cls.__init__) != inspect.signature(object.__init__):
+            sig = inspect.signature(cls.__init__)
+        else:
+            # No __new__ or __init__ method defined
+            return super().__init__(clsname, bases, attrs)
+
+        # Remove the first parameter (cls/self)
+        parameters = tuple(sig.parameters.values())
+        cls.__signature__ = sig.replace(parameters=parameters[1:])
+
+        return super().__init__(clsname, bases, attrs)
+
 
 class _ABCGufeClassMeta(_GufeTokenizableMeta, abc.ABCMeta):
     # required to make use of abc.ABC in classes that use _ComponentMeta
@@ -131,6 +149,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
 
     def __hash__(self):
         return hash(self.key)
+
 
     def _gufe_tokenize(self):
         """Return a list of normalized inputs for `gufe.base.tokenize`.


### PR DESCRIPTION
When the `inspect` module of the standard library is used to get the signature of a `GufeTokenizable` class, it sees that the metaclass has an implementation of `__call__` and takes the signature from that instead of from the `__new__` or `__init__` method of the child class:

```python
>>> from gufe import SmallMoleculeComponent
>>> import inspect
>>> inspect.signature(SmallMoleculeComponent)
<Signature (*args, **kwargs)>
>>> inspect.signature(SmallMoleculeComponent.__init__)
<Signature (self, rdkit: rdkit.Chem.rdchem.Mol, name: str = '')>
```

This results in unhelpful API documentation:

![SmallMoleculeComponent_signature_before](https://github.com/OpenFreeEnergy/gufe/assets/28590748/96c8370f-a852-4cd6-a02a-79812c4363c6)

But also may affect the signature displayed by IDEs, the Jupyter `help` magic, and so on.

This PR restores the signature from `__init__` or `__new__` when a child class is created:

![SmallMoleculeComponent_signature_after](https://github.com/OpenFreeEnergy/gufe/assets/28590748/5860116e-9109-49bc-a1a4-4277c598a3f1)

(I've taken screenshots from the GUFE docs, but this problem affects the OpenFE docs as well, and this solution fixes them too)

See https://stackoverflow.com/questions/49740290/call-from-metaclass-shadows-signature-of-init. I originally wrote a solution defining a `__signature__` property on the metaclass, but this solution seems more... canonical.


