### PR TITLE
Improve docstrings as needed for OpenFE

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,5 +10,5 @@ API docs
    api/protocols
    api/transformation
    api/settings
-   api/tokenization
+   api/serialize
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,4 +10,5 @@ API docs
    api/protocols
    api/transformation
    api/settings
+   api/tokenization
 

--- a/docs/api/components.rst
+++ b/docs/api/components.rst
@@ -25,3 +25,9 @@ Solvent Component
    
 .. autoclass:: gufe.components.SolventComponent
 	       :members:
+
+Chemical System
+===============
+
+.. autoclass:: gufe.chemicalsystem.ChemicalSystem
+	       :members:

--- a/docs/api/serialize.rst
+++ b/docs/api/serialize.rst
@@ -1,4 +1,4 @@
-GUFE Tokenization API
----------------------
+GUFE Serialization API
+----------------------
 
 .. autoclass:: gufe.tokenization.GufeTokenizable

--- a/docs/api/tokenization.rst
+++ b/docs/api/tokenization.rst
@@ -1,0 +1,4 @@
+GUFE Tokenization API
+---------------------
+
+.. autoclass:: gufe.tokenization.GufeTokenizable

--- a/docs/api/transformation.rst
+++ b/docs/api/transformation.rst
@@ -10,3 +10,8 @@ Alchemical network edges
 .. autoclass:: gufe.transformations.NonTransformation
            :members:
            :show-inheritance:
+
+Alchemical Networks
+===================
+
+.. autoclass:: gufe.network.AlchemicalNetwork

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,13 @@ extensions = [
 
 autoclass_content = 'both'
 
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "inherited-members": "GufeTokenizable",
+    "undoc-members": True,
+}
+
 intersphinx_mapping = {
     'rdkit': ('https://www.rdkit.org/docs/', None),
 }

--- a/gufe/chemicalsystem.py
+++ b/gufe/chemicalsystem.py
@@ -11,19 +11,8 @@ from .components import Component
 
 
 class ChemicalSystem(GufeTokenizable, abc.Mapping):
-    """A node of an alchemical network.
-
-    Attributes
-    ----------
-    components
-        The molecular representation of the chemical state, including
-        connectivity and coordinates. This is a frozendict with user-defined
-        labels as keys, :class:`.Component`\ s as values.
-    name
-        Optional identifier for the chemical state; used as part of the
-        (hashable) graph node itself when the chemical state is added to an
-        :class:`.AlchemicalNetwork`.
-
+    """
+    A node of an alchemical network; represents a system of chemicals.
     """
 
     def __init__(
@@ -73,11 +62,24 @@ class ChemicalSystem(GufeTokenizable, abc.Mapping):
         )
 
     @property
-    def components(self):
+    def components(self) -> dict[str, Component]:
+        """
+        The molecular representation of the chemical system.
+
+        Components include atomic connectivity and coordinates. This is a
+        frozendict with user-defined labels as keys and :class:`.Component`
+        instances as values.
+        """
         return dict(self._components)
 
     @property
     def name(self):
+        """
+        Optional identifier for the chemical system.
+
+        Used as part of the (hashable) graph node itself when the chemical state
+        is added to an :class:`.AlchemicalNetwork`.
+        """
         return self._name
 
     @property

--- a/gufe/components/component.py
+++ b/gufe/components/component.py
@@ -8,7 +8,7 @@ from ..tokenization import GufeTokenizable
 
 
 class Component(GufeTokenizable):
-    """Base class for members of a ChemicalSystem"""
+    """Base class for members of a :class:`ChemicalSystem`."""
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name={self.name})"
@@ -21,5 +21,5 @@ class Component(GufeTokenizable):
     @property
     @abc.abstractmethod
     def total_charge(self) -> Union[int, None]:
-        """Net formal charge for the Component if defined"""
+        """Net formal charge for the ``Component``, if defined."""
         ...

--- a/gufe/components/proteincomponent.py
+++ b/gufe/components/proteincomponent.py
@@ -56,7 +56,8 @@ positive_ions = ["NA", "MG", "ZN"]
 
 
 class ProteinComponent(ExplicitMoleculeComponent):
-    """Wrapper around a Protein representation.
+    """
+    :class:`Component` representing a protein.
 
     In comparison to a SmallMoleculeComponent, this representation additionally contains information
     relating to the residue and chain information.  This is achievable by having the MonomerInfo attributes

--- a/gufe/components/proteincomponent.py
+++ b/gufe/components/proteincomponent.py
@@ -57,12 +57,13 @@ positive_ions = ["NA", "MG", "ZN"]
 
 class ProteinComponent(ExplicitMoleculeComponent):
     """
-    :class:`Component` representing a protein.
+    ``Component`` representing the contents of a PDB file, such as a protein.
 
-    In comparison to a SmallMoleculeComponent, this representation additionally contains information
-    relating to the residue and chain information.  This is achievable by having the MonomerInfo attributes
-    present on each atom of the input RDKit molecule, which is done when reading from either PDB or `.mae`
-    file inputs.
+    In comparison to a SmallMoleculeComponent, this representation additionally
+    contains information relating to the residue and chain information.  This
+    is achievable by having the ``MonomerInfo`` attributes present on each atom
+    of the input RDKit molecule, which is done when reading from either PDB or
+    ``.mae`` file inputs.
 
     Note
     ----

--- a/gufe/components/smallmoleculecomponent.py
+++ b/gufe/components/smallmoleculecomponent.py
@@ -80,15 +80,17 @@ def _setprops(obj, d: dict) -> None:
 
 
 class SmallMoleculeComponent(ExplicitMoleculeComponent):
-    """A molecule wrapper suitable for small molecules
+    """
+    :class:`Component` representing a small molecule.
 
     .. note::
        This class is a read-only representation of a molecule, if you want to
        edit the molecule do this in an appropriate toolkit **before** creating
        an instance from this class.
 
-    This class supports reading/writing to the `.sdf` format, which is suited to smaller
-    molecules.
+    This class supports reading/writing to the `.sdf` format, which is suited to
+    smaller molecules. Ligands alchemically mutated in a free energy calculation
+    are typically represented with this class.
 
     The name can be explicitly set by the ``name`` attribute, or implicitly set
     based on the tags in the input molecular representation (if supported, as

--- a/gufe/components/solventcomponent.py
+++ b/gufe/components/solventcomponent.py
@@ -13,7 +13,8 @@ _ANIONS = {'Cl', 'Br', 'F', 'I'}
 
 # really wanted to make this a dataclass but then can't sort & strip ion input
 class SolventComponent(Component):
-    """Solvent molecules in a chemical state
+    """
+    :class:`Component` representing solvent molecules in a chemical system.
 
     This component represents the abstract idea of the solvent and ions present
     around the other components, rather than a list of specific water molecules

--- a/gufe/mapping/ligandatommapping.py
+++ b/gufe/mapping/ligandatommapping.py
@@ -12,7 +12,8 @@ from ..tokenization import JSON_HANDLER
 
 
 class LigandAtomMapping(AtomMapping):
-    """Simple container with the mapping between two Molecules
+    """
+    Simple container for an atom mapping between two small molecule components.
 
     """
     componentA: SmallMoleculeComponent

--- a/gufe/network.py
+++ b/gufe/network.py
@@ -13,19 +13,8 @@ from .transformations import Transformation
 class AlchemicalNetwork(GufeTokenizable):
     """A network with all the information needed for a simulation campaign.
 
-    Nodes are :class:`.ChemicalSystem`\ s and edges are
-    :class:`.Transformation`\ s.
-
-    Attributes
-    ----------
-    edges : frozenset[Transformation]
-        The edges of the network, given as a ``frozenset`` of
-        :class:`.Transformation`\ s.
-    nodes : frozenset[ChemicalSystem]
-        The nodes of the network, given as a ``frozenset`` of
-        :class:`.ChemicalSystem` \ s.
-    name : Optional identifier for the network.
-
+    Nodes are :class:`.ChemicalSystem` instances and edges are
+    :class:`.Transformation` instances.
     """
     def __init__(
         self,
@@ -74,14 +63,21 @@ class AlchemicalNetwork(GufeTokenizable):
 
     @property
     def edges(self) -> frozenset[Transformation]:
+        """
+        Network edges as a ``frozenset`` of :class:`.Transformation` instances.
+        """
         return self._edges
 
     @property
     def nodes(self) -> frozenset[ChemicalSystem]:
+        """
+        Network nodes as a ``frozenset`` of :class:`.ChemicalSystem` instances.
+        """
         return self._nodes
 
     @property
-    def name(self):
+    def name(self) -> Optional[str]:
+        """Optional identifier for the network."""
         return self._name
 
     def _to_dict(self) -> dict:

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -19,23 +19,16 @@ from .protocolunit import ProtocolUnit
 
 
 class ProtocolResult(GufeTokenizable):
-    """Container for all `ProtocolDAGResult`s for a given `Transformation`.
+    """
+    Container for all results for a single :class:`Transformation`.
 
-    This is an abstract base class; individual `Protocol` implementations
-    should have a corresponding subclass of `ProtocolResult` implemented as
-    well.
+    Contains a collection of :class:`ProtocolDAGResult` instances. This is an
+    abstract base class; individual `Protocol` implementations should have a
+    corresponding subclass of `ProtocolResult` implemented as well.
 
     The following methods should be implemented in any subclass:
     - `get_estimate`
     - `get_uncertainty`
-
-    Attributes
-    ----------
-    data : dict[str,Any]
-        Aggregated data contents from multiple `ProtocolDAGResult`s.
-        The structure of this data is specific to the `Protocol` subclass each
-        `ProtocolResult` subclass corresponds to.
-
     """
 
     def __init__(self, **data):
@@ -53,7 +46,13 @@ class ProtocolResult(GufeTokenizable):
         return cls(**dct)
 
     @property
-    def data(self):
+    def data(self) -> dict[str,Any]:
+        """
+        Aggregated data contents from multiple `ProtocolDAGResult` instances.
+
+        The structure of this data is specific to the `Protocol` subclass each
+        `ProtocolResult` subclass corresponds to.
+        """
         return self._data
 
     @abc.abstractmethod
@@ -79,15 +78,10 @@ class Protocol(GufeTokenizable):
     - `_create`
     - `_gather`
     - `_default_settings`
-
-    Attributes
-    ----------
-    result_cls : type[ProtocolResult]
-        Corresponding `ProtocolResult` subclass
-
     """
     _settings: Settings
     result_cls: type[ProtocolResult]
+    """Corresponding `ProtocolResult` subclass."""
 
     def __init__(self, settings: Settings):
         """Create a new ``Protocol`` instance.

--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -49,33 +49,30 @@ class DAGMixin:
         return reversed(list(nx.topological_sort(graph)))
 
     @property
-    def name(self):
+    def name(self) -> Optional[str]:
+        """Optional identifier."""
         return self._name
 
     @property
     def graph(self) -> nx.DiGraph:
-        """DAG of `ProtocolUnit`s that comprise this object.
-
-        """
+        """DAG of `ProtocolUnit` nodes with edges denoting dependencies."""
         return self._graph
 
     @property
     def protocol_units(self) -> list[ProtocolUnit]:
-        """List of `ProtocolUnit`s given in DAG-order.
-
-        """
+        """List of `ProtocolUnit`s given in DAG-dependency order."""
         return list(self._iterate_dag_order(self._graph))
 
     @property
     def transformation_key(self) -> Union[GufeKey, None]:
-        """The `GufeKey` of the `Transformation` this object performs.
+        """
+        The `GufeKey` of the `Transformation` this object performs.
 
         If `None`, then this object was not created from a `Transformation`.
         This may be the case when creating a `ProtocolDAG` from a `Protocol`
         directly, without use of a `Transformation` object.
 
         This functions as a label, indicating where this object came from.
-
         """
         return self._transformation_key
 
@@ -94,37 +91,11 @@ class DAGMixin:
 
 
 class ProtocolDAGResult(GufeTokenizable, DAGMixin):
-    """Result for a single `ProtocolDAG` execution.
+    """
+    Result for a single execution of an entire :class:`ProtocolDAG`.
 
     There may be many of these for a given `Transformation`. Data elements from
     these objects are combined by `Protocol.gather` into a `ProtocolResult`.
-
-    Attributes
-    ----------
-    name : str
-        Optional identifier for this `ProtocolDAGResult`.
-    protocol_units : list[ProtocolUnit]
-        `ProtocolUnit`s (given in DAG-dependency order) used to compute this
-        `ProtocolDAGResult`.
-    protocol_unit_results : list[ProtocolUnitResult]
-        `ProtocolUnitResult`s (given in DAG-dependency order) corresponding to
-        each `ProtocolUnit` used to compute this `ProtocolDAGResult`.
-    graph : nx.DiGraph
-        Graph of `ProtocolUnit`s as nodes, with directed edges to each
-        `ProtocolUnit`'s dependencies.
-    result_graph : nx.DiGraph
-        Graph of `ProtocolUnitResult`s as nodes, with directed edges to each
-        `ProtocolUnitResult`'s dependencies.
-    transformation_key : Union[GufeKey, None]
-        Key of the `Transformation` that this `ProtocolDAGResult` corresponds
-        to, if applicable. This functions as a label for identifying the source
-        of this `ProtocolDAGResult`.
-    extends_key : Optional[GufeKey]
-        Key of the `ProtocolDAGResult` that this `ProtocolDAGResult` extends from.
-        This functions as a label for identifying the source of this `ProtocolDAGResult`;
-        it can be used to reconstruct the tree of extensions from a collection
-        of `ProtocolUnitResult`\s.
-
     """
     _protocol_unit_results: list[ProtocolUnitResult]
     _unit_result_mapping: dict[ProtocolUnit, list[ProtocolUnitResult]]
@@ -181,10 +152,18 @@ class ProtocolDAGResult(GufeTokenizable, DAGMixin):
 
     @property
     def result_graph(self) -> nx.DiGraph:
+        """
+        DAG of `ProtocolUnitResult` nodes with edges denoting dependencies.
+        """
         return self._result_graph
 
     @property
     def protocol_unit_results(self) -> list[ProtocolUnitResult]:
+        """
+        `ProtocolUnitResult`s for each `ProtocolUnit` used to compute this object.
+
+        Results are given in DAG-dependency order.
+        """
         return list(self._iterate_dag_order(self.result_graph))
 
     @property
@@ -277,12 +256,13 @@ class ProtocolDAGResult(GufeTokenizable, DAGMixin):
 
 
 class ProtocolDAG(GufeTokenizable, DAGMixin):
-    """An executable directed, acyclic graph (DAG) composed of `ProtocolUnit`
-    with dependencies specified.
+    """
+    An executable directed acyclic graph (DAG) of :class:`ProtocolUnit` objects.
 
-    A single `ProtocolDAG` execution should yield sufficient information to
-    calculate a free energy difference (though perhaps not converged) between
-    two `ChemicalSystem` objects.
+    A ``ProtocolDAG`` is composed of :class:`ProtocolUnit` objects as well as
+    how they depend on each other. A single `ProtocolDAG` execution should
+    yield sufficient information to calculate a free energy difference
+    (though perhaps not converged) between two `ChemicalSystem` objects.
     
     A `ProtocolDAG` yields a `ProtocolDAGResult` when executed.
 
@@ -361,7 +341,8 @@ def execute_DAG(protocoldag: ProtocolDAG, *,
                 raise_error: bool = True,
                 n_retries: int = 0,
                 ) -> ProtocolDAGResult:
-    """Locally execute a full ProtocolDAG in-serial, in process.
+    """
+    Locally execute a full :class:`ProtocolDAG` in serial and in-process.
 
     Parameters
     ----------

--- a/gufe/protocols/protocolunit.py
+++ b/gufe/protocols/protocolunit.py
@@ -51,6 +51,10 @@ def _list_dependencies(inputs, cls):
 
 
 class ProtocolUnitResult(GufeTokenizable):
+    """
+    Successful result of a single :class:`ProtocolUnit` execution.
+    """
+
     def __init__(self, *,
             name: Optional[str] = None,
             source_key: GufeKey,
@@ -59,8 +63,7 @@ class ProtocolUnitResult(GufeTokenizable):
             start_time: Optional[datetime.datetime] = None,
             end_time: Optional[datetime.datetime] = None,
         ):
-        """Generate a `ProtocolUnitResult`.
-
+        """
         Parameters
         ----------
         name : Optional[str]
@@ -153,7 +156,7 @@ class ProtocolUnitResult(GufeTokenizable):
 
 
 class ProtocolUnitFailure(ProtocolUnitResult):
-    """Failed result for a single `ProtocolUnit` execution."""
+    """Failed result of a single :class:`ProtocolUnit` execution."""
 
     def __init__(
             self,
@@ -214,17 +217,7 @@ class ProtocolUnitFailure(ProtocolUnitResult):
 
 
 class ProtocolUnit(GufeTokenizable):
-    """A unit of work within a ProtocolDAG.
-
-    Attributes
-    ----------
-    name : Optional[str]
-        Optional name for the `ProtocolUnit`.
-    inputs : Dict[str, Any]
-        Inputs to the `ProtocolUnit`. Includes any `ProtocolUnit`s this
-        `ProtocolUnit` is dependent on.
-
-    """
+    """A unit of work within a ProtocolDAG."""
     _dependencies: Optional[list[ProtocolUnit]]
 
     def __init__(
@@ -278,11 +271,19 @@ class ProtocolUnit(GufeTokenizable):
         return obj
 
     @property
-    def name(self):
+    def name(self) -> Optional[str]:
+        """
+        Optional name for the `ProtocolUnit`.
+        """
         return self._name
 
     @property
-    def inputs(self):
+    def inputs(self) -> Dict[str, Any]:
+        """
+        Inputs to the `ProtocolUnit`.
+
+        Includes any `ProtocolUnit` instances this `ProtocolUnit` depends on.
+        """
         return copy(self._inputs)
 
     @property

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -199,7 +199,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         """Dict of default key-value pairs for this `GufeTokenizable` object.
 
         These defaults are stripped from the dict form of this object produced
-        with `to_dict(include_defaults=False)` where default values are present.
+        with ``to_dict(include_defaults=False)`` where default values are present.
 
         """
         return cls._defaults()

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -199,7 +199,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         """Dict of default key-value pairs for this `GufeTokenizable` object.
 
         These defaults are stripped from the dict form of this object produced
-        with `to_dict(include_defaults=False) where default values are present.
+        with `to_dict(include_defaults=False)` where default values are present.
 
         """
         return cls._defaults()


### PR DESCRIPTION
This PR moves more docstrings out of `attribute` sections of docstrings and onto the corresponding object itself. This helps comprehensive API documentation in OpenFE. Required by https://github.com/OpenFreeEnergy/openfe/pull/527