### PR TITLE
adding mol name labels from ofe-name to mapping vis

### DIFF
--- a/gufe/visualization/mapping_visualization.py
+++ b/gufe/visualization/mapping_visualization.py
@@ -149,7 +149,7 @@ def _draw_molecules(
 
     # get molecule name labels
     labels = [m.GetProp("ofe-name") if(m.HasProp("ofe-name"))
-                else "" for m in mols]
+              else "" for m in mols]
 
     # squash to 2D
     copies = [Chem.Mol(mol) for mol in mols]

--- a/gufe/visualization/mapping_visualization.py
+++ b/gufe/visualization/mapping_visualization.py
@@ -147,6 +147,9 @@ def _draw_molecules(
         d2d = Draw.rdMolDraw2D.MolDraw2DCairo(
             grid_x * 300, grid_y * 300, 300, 300)
 
+    # get molecule name labels
+    labels = [m.GetProp("ofe-name") for m in copies]
+
     # squash to 2D
     copies = [Chem.Mol(mol) for mol in mols]
     for mol in copies:
@@ -170,6 +173,7 @@ def _draw_molecules(
         highlightBonds=bonds_list,
         highlightAtomColors=atom_colors,
         highlightBondColors=bond_colors,
+        legends=labels,
     )
     d2d.FinishDrawing()
     return d2d.GetDrawingText()

--- a/gufe/visualization/mapping_visualization.py
+++ b/gufe/visualization/mapping_visualization.py
@@ -148,7 +148,8 @@ def _draw_molecules(
             grid_x * 300, grid_y * 300, 300, 300)
 
     # get molecule name labels
-    labels = [m.GetProp("ofe-name") if(m.HasProp("ofe-name")) else "" for m in mols]
+    labels = [m.GetProp("ofe-name") if(m.HasProp("ofe-name"))
+                else "" for m in mols]
 
     # squash to 2D
     copies = [Chem.Mol(mol) for mol in mols]

--- a/gufe/visualization/mapping_visualization.py
+++ b/gufe/visualization/mapping_visualization.py
@@ -148,7 +148,7 @@ def _draw_molecules(
             grid_x * 300, grid_y * 300, 300, 300)
 
     # get molecule name labels
-    labels = [m.GetProp("ofe-name") for m in copies]
+    labels = [m.GetProp("ofe-name") if(m.HasProp("ofe-name")) else "" for m in mols]
 
     # squash to 2D
     copies = [Chem.Mol(mol) for mol in mols]


### PR DESCRIPTION
This pull request adds one nice small features to gufe mapping visualization:
- labeling mapped molecules with their `ofe-name`
![image](https://github.com/OpenFreeEnergy/gufe/assets/12428005/a37a7b18-7899-4ba9-bfa8-f41582677df1)
