### PR TITLE
Switch to OFE theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ autodoc_mock_imports = ["openff.models",
 #
 html_theme = "ofe_sphinx_theme"
 html_theme_options = {
-    "accent_color": "FeelingSpicy",
+    "accent_color": "FeelingFabulous",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,10 @@ autodoc_mock_imports = ["openff.models",
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pydata_sphinx_theme'
+html_theme = "ofe_sphinx_theme"
+html_theme_options = {
+    "accent_color": "FeelingSpicy",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -5,7 +5,8 @@ channels:
 dependencies:
 - autodoc-pydantic
 - openff-units
-- pydata-sphinx-theme
-- python=3.9
+- python=3.10
 - sphinx
 - openmm
+- pip:
+  - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@main


### PR DESCRIPTION
This theme just adapts and updates the CSS from ``openfe`` to a new theme so it can be shared across all OpenFE projects. I've chosen the FeelingFabulous accent color to distinguish gufe, but this can easily be changed!