### PR TITLE
Don't run conda_cron on PRs

### DIFF
--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -1,8 +1,5 @@
 name: "conda_cron"
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     # At 07:00 UTC every day
     - cron: "0 7 * * *"


### PR DESCRIPTION
Looks like this change was accidentally merged, when it was just intended to get the workflow to run to ensure that the other changes in #232 fixed things.