### PR TITLE
change signature of Protocol.create to have a list of ComponentMappings

### DIFF
--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -197,10 +197,10 @@ class LigandNetwork(GufeTokenizable):
         components: dict[str, :class:`.Component`]
             non-alchemical components (components that will be on both sides
             of a transformation)
-        leg_label: dict[str, list[str]]
+        leg_labels: dict[str, list[str]]
             mapping of the names for legs (the keys of this dict) to a list
-            of the component names. The componnent names must be the same as
-            as used in the ``componentns`` dict.
+            of the component names. The component names must be the same as
+            used in the ``components`` dict.
         protocol: :class:`.Protocol`
             the protocol to apply
         alchemical_label: str
@@ -237,12 +237,9 @@ class LigandNetwork(GufeTokenizable):
                 else:
                     name = ""
 
-                mapping: dict[str, gufe.ComponentMapping] = {
-                    alchemical_label: edge,
-                }
-
                 transformation = gufe.Transformation(sysA, sysB, protocol,
-                                                     mapping, name)
+                                                     mapping=edge,
+                                                     name=name)
 
                 transformations.append(transformation)
 

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -171,7 +171,7 @@ class Protocol(GufeTokenizable):
         *,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Union[dict[str, ComponentMapping], None],
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping], None]],
         extends: Optional[ProtocolDAGResult] = None,
         name: Optional[str] = None,
         transformation_key: Optional[GufeKey] = None
@@ -193,9 +193,9 @@ class Protocol(GufeTokenizable):
             The starting `ChemicalSystem` for the transformation.
         stateB : ChemicalSystem
             The ending `ChemicalSystem` for the transformation.
-        mapping : Optional[dict[str, ComponentMapping]]
+        mapping : Optional[ComponentMapping | list[ComponentMapping]]
             Mappings of e.g. atoms between a labelled component in the
-             stateA and stateB `ChemicalSystem` .
+            stateA and stateB `ChemicalSystem` .
         extends : Optional[ProtocolDAGResult]
             If provided, then the `ProtocolDAG` produced will start from the
             end state of the given `ProtocolDAGResult`. This allows for

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -135,15 +135,16 @@ class Protocol(GufeTokenizable):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[dict[str, ComponentMapping]] = None,
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
         extends: Optional[ProtocolDAGResult] = None,
     ) -> list[ProtocolUnit]:
         """Method to override in custom :class:`Protocol` subclasses.
 
-        This method should take two `ChemicalSystem`s, and optionally a
-        dict mapping string to ``ComponentMapping``, and prepare a collection of ``ProtocolUnit`` instances
-        that when executed in order give sufficient information to estimate the
-        free energy difference between those two `ChemicalSystem`s.
+        This method should take two `ChemicalSystem`s, and optionally one or
+        more ``ComponentMapping`` objects, and prepare a collection of
+        ``ProtocolUnit`` instances that when executed in order give sufficient
+        information to estimate the free energy difference between those two
+        `ChemicalSystem`s.
 
         This method should return a list of `ProtocolUnit` instances.
         For an instance in which another `ProtocolUnit` is given as a parameter

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -171,7 +171,7 @@ class Protocol(GufeTokenizable):
         *,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[Union[ComponentMapping, list[ComponentMapping], None]],
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]],
         extends: Optional[ProtocolDAGResult] = None,
         name: Optional[str] = None,
         transformation_key: Optional[GufeKey] = None
@@ -215,14 +215,6 @@ class Protocol(GufeTokenizable):
             A directed, acyclic graph that can be executed by a `Scheduler`.
 
         """
-        # coerce mapping argument into list for _create signature
-        # top level "create" allows more intuitive input
-        # internal "_create" provides guaranteed type
-        if mapping is None:
-            mapping = []
-        elif isinstance(mapping, ComponentMapping):
-            mapping = [mapping]
-
         return ProtocolDAG(
             name=name,
             protocol_units=self._create(

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -193,7 +193,7 @@ class Protocol(GufeTokenizable):
             The starting `ChemicalSystem` for the transformation.
         stateB : ChemicalSystem
             The ending `ChemicalSystem` for the transformation.
-        mapping : Optional[ComponentMapping, list[ComponentMapping]]
+        mapping : Optional[Union[ComponentMapping, list[ComponentMapping]]]
             Mappings of e.g. atoms between a labelled component in the
             stateA and stateB `ChemicalSystem` .
         extends : Optional[ProtocolDAGResult]

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -135,13 +135,13 @@ class Protocol(GufeTokenizable):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
+        mapping: list[ComponentMapping],
         extends: Optional[ProtocolDAGResult] = None,
     ) -> list[ProtocolUnit]:
         """Method to override in custom :class:`Protocol` subclasses.
 
-        This method should take two `ChemicalSystem`s, and optionally one or
-        more ``ComponentMapping`` objects, and prepare a collection of
+        This method should take two `ChemicalSystem`s, and zero or more
+        ``ComponentMapping`` objects, and prepare a collection of
         ``ProtocolUnit`` instances that when executed in order give sufficient
         information to estimate the free energy difference between those two
         `ChemicalSystem`s.
@@ -215,6 +215,14 @@ class Protocol(GufeTokenizable):
             A directed, acyclic graph that can be executed by a `Scheduler`.
 
         """
+        # coerce mapping argument into list for _create signature
+        # top level "create" allows more intuitive input
+        # internal "_create" provides guaranteed type
+        if mapping is None:
+            mapping = []
+        elif isinstance(mapping, ComponentMapping):
+            mapping = [mapping]
+
         return ProtocolDAG(
             name=name,
             protocol_units=self._create(

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -135,13 +135,13 @@ class Protocol(GufeTokenizable):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: list[ComponentMapping],
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]],
         extends: Optional[ProtocolDAGResult] = None,
     ) -> list[ProtocolUnit]:
         """Method to override in custom :class:`Protocol` subclasses.
 
-        This method should take two `ChemicalSystem`s, and zero or more
-        ``ComponentMapping`` objects, and prepare a collection of
+        This method should take two `ChemicalSystem`s, and optionally one or
+         more ``ComponentMapping`` objects, and prepare a collection of
         ``ProtocolUnit`` instances that when executed in order give sufficient
         information to estimate the free energy difference between those two
         `ChemicalSystem`s.
@@ -193,7 +193,7 @@ class Protocol(GufeTokenizable):
             The starting `ChemicalSystem` for the transformation.
         stateB : ChemicalSystem
             The ending `ChemicalSystem` for the transformation.
-        mapping : Optional[ComponentMapping | list[ComponentMapping]]
+        mapping : Optional[ComponentMapping, list[ComponentMapping]]
             Mappings of e.g. atoms between a labelled component in the
             stateA and stateB `ChemicalSystem` .
         extends : Optional[ProtocolDAGResult]

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -343,8 +343,9 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
             assert compsA.get('protein') == compsB.get('protein')
             assert compsA.get('cofactor') == compsB.get('cofactor')
 
-            assert list(edge.mapping) == ['ligand']
-            assert edge.mapping['ligand'] in real_molecules_network.edges
+            assert isinstance(edge.mapping, list)
+            assert len(edge.mapping) == 1
+            assert edge.mapping[0] in real_molecules_network.edges
 
     def test_to_rbfe_alchemical_network_autoname_false(
         self,

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -343,9 +343,8 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
             assert compsA.get('protein') == compsB.get('protein')
             assert compsA.get('cofactor') == compsB.get('cofactor')
 
-            assert isinstance(edge.mapping, list)
-            assert len(edge.mapping) == 1
-            assert edge.mapping[0] in real_molecules_network.edges
+            assert isinstance(edge.mapping, gufe.ComponentMapping)
+            assert edge.mapping in real_molecules_network.edges
 
     def test_to_rbfe_alchemical_network_autoname_false(
         self,

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -112,7 +112,7 @@ class DummyProtocol(Protocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
+        mapping: list[ComponentMapping],
         extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
 
@@ -172,7 +172,7 @@ class BrokenProtocol(DummyProtocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
+        mapping: list[ComponentMapping],
         extends: Optional[ProtocolDAGResult] = None,
     ) -> list[ProtocolUnit]:
 
@@ -513,7 +513,7 @@ class NoDepsProtocol(Protocol):
             self,
             stateA: ChemicalSystem,
             stateB: ChemicalSystem,
-            mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
+            mapping: list[ComponentMapping],
             extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
         return [NoDepUnit(settings=self.settings,

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -112,7 +112,7 @@ class DummyProtocol(Protocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[dict[str, ComponentMapping]] = None,
+        mapping: Optional[list[ComponentMapping]] = None,
         extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
 
@@ -172,7 +172,7 @@ class BrokenProtocol(DummyProtocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[dict[str, ComponentMapping]] = None,
+        mapping: Optional[list[ComponentMapping]] = None,
         extends: Optional[ProtocolDAGResult] = None,
     ) -> list[ProtocolUnit]:
 
@@ -513,7 +513,7 @@ class NoDepsProtocol(Protocol):
             self,
             stateA: ChemicalSystem,
             stateB: ChemicalSystem,
-            mapping: Optional[dict[str, ComponentMapping]] = None,
+            mapping: Optional[list[ComponentMapping]] = None,
             extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
         return [NoDepUnit(settings=self.settings,

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -112,7 +112,7 @@ class DummyProtocol(Protocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[list[ComponentMapping]] = None,
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
         extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
 
@@ -172,7 +172,7 @@ class BrokenProtocol(DummyProtocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: Optional[list[ComponentMapping]] = None,
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
         extends: Optional[ProtocolDAGResult] = None,
     ) -> list[ProtocolUnit]:
 
@@ -513,7 +513,7 @@ class NoDepsProtocol(Protocol):
             self,
             stateA: ChemicalSystem,
             stateB: ChemicalSystem,
-            mapping: Optional[list[ComponentMapping]] = None,
+            mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
             extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
         return [NoDepUnit(settings=self.settings,

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -112,7 +112,7 @@ class DummyProtocol(Protocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: list[ComponentMapping],
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]]=None,
         extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
 
@@ -172,7 +172,7 @@ class BrokenProtocol(DummyProtocol):
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: list[ComponentMapping],
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]]=None,
         extends: Optional[ProtocolDAGResult] = None,
     ) -> list[ProtocolUnit]:
 
@@ -513,7 +513,7 @@ class NoDepsProtocol(Protocol):
             self,
             stateA: ChemicalSystem,
             stateB: ChemicalSystem,
-            mapping: list[ComponentMapping],
+            mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
             extends: Optional[ProtocolDAGResult] = None,
     ) -> List[ProtocolUnit]:
         return [NoDepUnit(settings=self.settings,

--- a/gufe/tests/test_protocoldag.py
+++ b/gufe/tests/test_protocoldag.py
@@ -69,7 +69,7 @@ def writefile_dag():
 
     p = WriterProtocol(settings=WriterProtocol.default_settings())
 
-    return p.create(stateA=s1, stateB=s2, mapping={})
+    return p.create(stateA=s1, stateB=s2, mapping=[])
 
 
 @pytest.mark.parametrize('keep_shared', [False, True])

--- a/gufe/tests/test_protocoldag.py
+++ b/gufe/tests/test_protocoldag.py
@@ -53,9 +53,9 @@ class WriterProtocol(gufe.Protocol):
     def _defaults(cls):
         return {}
 
-    def _create(self, stateA,  stateB, mapping=None, extends=None) -> list[gufe.ProtocolUnit]:
+    def _create(self, stateA,  stateB, mapping, extends=None) -> list[gufe.ProtocolUnit]:
         return [
-            WriterUnit(identity=i) for i in range(self.settings.n_repeats) # type: ignore
+            WriterUnit(identity=i) for i in range(self.settings.n_repeats)  # type: ignore
         ]
 
     def _gather(self, results):

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -20,7 +20,7 @@ class Transformation(GufeTokenizable):
     _stateA: ChemicalSystem
     _stateB: ChemicalSystem
     _name: Optional[str]
-    _mapping: Optional[list[ComponentMapping]]
+    _mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]]
     _protocol: Protocol
 
     def __init__(
@@ -31,11 +31,8 @@ class Transformation(GufeTokenizable):
         mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
         name: Optional[str] = None,
     ):
-
         self._stateA = stateA
         self._stateB = stateB
-        if isinstance(mapping, ComponentMapping):
-            mapping = [mapping]
         self._mapping = mapping
         self._name = name
 
@@ -71,7 +68,7 @@ class Transformation(GufeTokenizable):
         return self._protocol
 
     @property
-    def mapping(self) -> Optional[list[ComponentMapping]]:
+    def mapping(self) -> Optional[Union[ComponentMapping, list[ComponentMapping]]]:
         """The mappings relevant for this Transformation"""
         return self._mapping
 

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -23,7 +23,7 @@ class Transformation(GufeTokenizable):
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
         protocol: Protocol,
-        mapping: Optional[dict[str, ComponentMapping]] = None,
+        mapping: Optional[list[ComponentMapping]] = None,
         name: Optional[str] = None,
     ):
 

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -1,7 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
-from typing import Optional, Iterable
+from typing import Optional, Iterable, Union
 import json
 
 from ..tokenization import GufeTokenizable, JSON_HANDLER
@@ -17,18 +17,25 @@ class Transformation(GufeTokenizable):
 
     Connects two :class:`ChemicalSystem` objects, with directionality.
     """
+    _stateA: ChemicalSystem
+    _stateB: ChemicalSystem
+    _name: Optional[str]
+    _mapping: Optional[list[ComponentMapping]]
+    _protocol: Protocol
 
     def __init__(
         self,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
         protocol: Protocol,
-        mapping: Optional[list[ComponentMapping]] = None,
+        mapping: Optional[Union[ComponentMapping, list[ComponentMapping]]] = None,
         name: Optional[str] = None,
     ):
 
         self._stateA = stateA
         self._stateB = stateB
+        if isinstance(mapping, ComponentMapping):
+            mapping = [mapping]
         self._mapping = mapping
         self._name = name
 
@@ -64,10 +71,8 @@ class Transformation(GufeTokenizable):
         return self._protocol
 
     @property
-    def mapping(self) -> Optional[dict[str, ComponentMapping]]:
-        """
-        Mapping of e.g. atoms between ``stateA`` and ``stateB``.
-        """
+    def mapping(self) -> Optional[list[ComponentMapping]]:
+        """The mappings relevant for this Transformation"""
         return self._mapping
 
     @property


### PR DESCRIPTION
was previously a `dict[str, ComponentMapping]` where the strings were arbitrary labels.  These arbitrary labels were superfluous.  Instead can use the arbitrary labels on ChemicalSystems to label components.  (ComponentMappings can (and should) be matched against components in ChemicalSystem using the Component eq operations.)

This now accepts either a single ComponentMapping (covers most cases), or None (covers ABFE), or a list (handles future things?)

also affects Transformation object, which was essentially wrapper around Protocol + ChemicalSystem