### PR TITLE
fixes issue #274

### DIFF
--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -112,7 +112,10 @@ class Protocol(GufeTokenizable):
 
     @classmethod
     @abc.abstractmethod
-    def _default_settings(cls) -> Settings:
+    def _default_settings(cls, *,
+                          stateA: Optional[ChemicalSystem] = None,
+                          stateB: Optional[ChemicalSystem] = None,
+                          ) -> Settings:
         """Method to override in custom `Protocol` subclasses.
 
         Gives a usable instance of ``Settings`` that function as
@@ -122,14 +125,23 @@ class Protocol(GufeTokenizable):
         raise NotImplementedError()
 
     @classmethod
-    def default_settings(cls) -> Settings:
+    def default_settings(cls, *,
+                         stateA: Optional[ChemicalSystem] = None,
+                         stateB: Optional[ChemicalSystem] = None,
+                         ) -> Settings:
         """Get the default settings for this `Protocol`.
 
         These can be modified and passed in as the `settings` for a new
         `Protocol` instance.
 
+        Parameters
+        ----------
+        stateA, stateB: ChemicalSystem, optional
+          details of the chemistry that the Protocol will operate on.
+          Depending on implementation, this can be used to fine tune the
+          default settings which are used.
         """
-        return cls._default_settings()
+        return cls._default_settings(stateA=stateA, stateB=stateB)
 
     @abc.abstractmethod
     def _create(

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -518,7 +518,7 @@ class NoDepsProtocol(Protocol):
         return {}
 
     @classmethod
-    def _default_settings(cls):
+    def _default_settings(cls, stateA=None, stateB=None):
         return settings.Settings.get_defaults()
 
     def _create(

--- a/gufe/tests/test_protocoldag.py
+++ b/gufe/tests/test_protocoldag.py
@@ -41,7 +41,7 @@ class WriterProtocol(gufe.Protocol):
     result_cls = WriterProtocolResult
 
     @classmethod
-    def _default_settings(cls):
+    def _default_settings(cls, stateA=None, stateB=None):
         return WriterSettings(
             thermo_settings=gufe.settings.ThermoSettings(temperature=298 * unit.kelvin),
             forcefield_settings=gufe.settings.OpenMMSystemGeneratorFFSettings(),


### PR DESCRIPTION
adds optional ChemicalSystem arguments to default_settings.

these can optionally be used to allow the default settings of a Protocol to adapt to the chemistry that will be encountered