### PR TITLE
fixes issue #263

### DIFF
--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -43,7 +43,7 @@ class SettingsBaseModel(DefaultModel):
         arbitrary_types_allowed = False
         smart_union = True
 
-    def _ipython_display_(self, d2d=None):
+    def _ipython_display_(self):
         pprint.pprint(self.dict())
 
     def frozen_copy(self):

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -10,6 +10,7 @@ from typing import Optional, Union
 from openff.models.models import DefaultModel
 from openff.models.types import FloatQuantity
 from openff.units import unit
+import pprint
 
 try:
     from pydantic.v1 import (
@@ -41,6 +42,9 @@ class SettingsBaseModel(DefaultModel):
         extra = pydantic.Extra.forbid
         arbitrary_types_allowed = False
         smart_union = True
+
+    def _ipython_display_(self, d2d=None):
+        pprint.pprint(self.dict())
 
     def frozen_copy(self):
         """A copy of this Settings object which cannot be modified


### PR DESCRIPTION
adds _ipython_display_ to SettingsBaseModel

this pretty prints the nested settings

![Screenshot_20240201_124005](https://github.com/OpenFreeEnergy/gufe/assets/9249543/a0e97147-0718-49a9-9f70-6045e3dc538c)
