### PR TITLE
Bump CodeCov action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: codecov
         if: ${{ github.repository == 'OpenFreeEnergy/gufe'
                 && github.event != 'schedule' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.xml


### PR DESCRIPTION
This isn't strictly needed yet but I'm paranoid about them once again leaking credentials and not reporting it so I'm poking around repos that are still on v3.

You can set up the bot to do this, if you're into that: https://github.com/openforcefield/openff-toolkit/blob/main/.github/dependabot.yml