### PR TITLE
Add KeyedChain GufeTokenizable representation

### DIFF
--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -10,7 +10,7 @@ from typing import Optional
 from gufe.tokenization import (
     GufeTokenizable, GufeKey, tokenize, TOKENIZABLE_REGISTRY,
     import_qualname, get_class, TOKENIZABLE_CLASS_REGISTRY, JSON_HANDLER,
-    get_all_gufe_objs,
+    get_all_gufe_objs, KeyedChain
 )
 
 

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -10,7 +10,8 @@ from typing import Optional
 from gufe.tokenization import (
     GufeTokenizable, GufeKey, tokenize, TOKENIZABLE_REGISTRY,
     import_qualname, get_class, TOKENIZABLE_CLASS_REGISTRY, JSON_HANDLER,
-    get_all_gufe_objs, KeyedChain
+    get_all_gufe_objs, gufe_to_digraph, gufe_objects_from_shallow_dict,
+    KeyedChain,
 )
 
 
@@ -378,6 +379,58 @@ class TestGufeKey:
         k = GufeKey('foo-bar')
 
         assert k.token == 'bar'
+
+
+def test_gufe_to_digraph(solvated_complex):
+    graph = gufe_to_digraph(solvated_complex)
+
+    connected_objects = gufe_objects_from_shallow_dict(
+        solvated_complex.to_shallow_dict()
+    )
+
+    assert len(graph.nodes) == 4
+    assert len(graph.edges) == 3
+
+    for node_a, node_b in graph.edges:
+        assert node_b in connected_objects
+        assert node_a is solvated_complex
+
+
+def test_gufe_objects_from_shallow_dict(solvated_complex):
+    shallow_dict = solvated_complex.to_shallow_dict()
+    gufe_objects = set(gufe_objects_from_shallow_dict(shallow_dict))
+
+    assert len(gufe_objects) == 3
+
+    for gufe_object in gufe_objects:
+        assert gufe_object in solvated_complex.components.values()
+
+
+class TestKeyedChain:
+
+    def test_from_gufe(self, benzene_variants_star_map):
+        contained_objects = list(get_all_gufe_objs(benzene_variants_star_map))
+        expected_len = len(contained_objects)
+
+        kc = KeyedChain.from_gufe(benzene_variants_star_map)
+
+        assert len(kc) == expected_len
+
+        original_keys = [obj.key for obj in contained_objects]
+        original_keyed_dicts = [
+            obj.to_keyed_dict() for obj in contained_objects
+        ]
+
+        kc_gufe_keys = set(kc.gufe_keys())
+        kc_shallow_dicts = list(kc.keyed_dicts())
+
+        for key, keyed_dict in zip(original_keys, original_keyed_dicts):
+            assert key in kc_gufe_keys
+            assert keyed_dict in kc_shallow_dicts
+
+    def test_to_gufe(self, benzene_variants_star_map):
+        kc = KeyedChain.from_gufe(benzene_variants_star_map)
+        assert hash(kc.to_gufe()) == hash(benzene_variants_star_map)
 
 
 def test_datetime_to_json():

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -432,6 +432,13 @@ class TestKeyedChain:
         kc = KeyedChain.from_gufe(benzene_variants_star_map)
         assert hash(kc.to_gufe()) == hash(benzene_variants_star_map)
 
+    def test_get_item(self, benzene_variants_star_map):
+        kc = KeyedChain.from_gufe(benzene_variants_star_map)
+
+        assert kc[0] == kc._keyed_chain[0]
+        assert kc[-1] == kc._keyed_chain[-1]
+        assert kc[:] == kc._keyed_chain[:]
+
 
 def test_datetime_to_json():
     d = datetime.datetime.fromisoformat('2023-05-05T09:06:43.699068')

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -752,7 +752,7 @@ class KeyedChain(object):
     def gufe_to_keyed_chain_rep(
         gufe_object: GufeTokenizable,
     ) -> List[Tuple[str, Dict]]:
-        """Create the keyed chain represenation of a GufeTokenizable.
+        """Create the keyed chain representation of a GufeTokenizable.
 
         This represents the GufeTokenizable as a list of two-element tuples
         containing, as their first and second elements, the gufe key and keyed
@@ -767,7 +767,7 @@ class KeyedChain(object):
         Returns
         -------
         key_and_keyed_dicts
-            The keyed chain represenation of a GufeTokenizable.
+            The keyed chain representation of a GufeTokenizable.
 
         """
         key_and_keyed_dicts = [

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -14,7 +14,8 @@ import re
 import warnings
 import weakref
 from itertools import chain
-from typing import Any, Union, List, Tuple, Dict, Generator, Self
+from typing import Any, Union, List, Tuple, Dict, Generator
+from typing_extensions import Self
 
 from gufe.custom_codecs import (
     BYTES_CODEC,

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -9,10 +9,12 @@ import importlib
 import inspect
 import json
 import logging
+import networkx as nx
 import re
-import weakref
 import warnings
-from typing import Any, Union
+import weakref
+from itertools import chain
+from typing import Any, Union, List, Tuple, Dict, Generator
 
 from gufe.custom_codecs import (
     BYTES_CODEC,
@@ -635,6 +637,159 @@ class GufeKey(str):
         """Unique hash of this key, typically a md5 value"""
         return self.split('-')[1]
 
+def gufe_to_digraph(gufe_obj):
+    """Recursively construct a DiGraph from a GufeTokenizable.
+
+    The DiGraph encodes the dependency structure of the GufeTokenizable on
+    other GufeTokenizables.
+    """
+    graph = nx.DiGraph()
+    shallow_dicts = {}
+
+    def add_edges(o):
+        # if we've made a shallow dict before, we've already added this one
+        # and all its dependencies; return `None` to avoid going down the tree
+        # again
+        sd = shallow_dicts.get(o.key)
+        if sd is not None:
+            return None
+
+        # if not, then we make the shallow dict only once, add it to our index,
+        # add edges to dependencies, and return it so we continue down the tree
+        sd = o.to_shallow_dict()
+
+        shallow_dicts[o.key] = sd
+
+        # add the object node in case there aren't any connections
+        graph.add_node(o)
+        connections = gufe_objects_from_shallow_dict(sd)
+
+        for c in connections:
+            graph.add_edge(o, c)
+
+        return sd
+
+    sd = add_edges(gufe_obj)
+    _ = modify_dependencies(sd, add_edges, is_gufe_obj, mode="encode")
+
+    return graph
+
+def gufe_objects_from_shallow_dict(
+    obj: Union[List, Dict, GufeTokenizable]
+) -> List[GufeTokenizable]:
+    """Find GufeTokenizables within a shallow dict.
+
+    This function recursively looks through the list/dict structures encoding
+    GufeTokenizables and returns list of all GufeTokenizables found
+    within those structures, which may be potentially nested.
+
+    Parameters
+    ----------
+    obj
+        The input data structure to recursively traverse. For the initial call
+        of this function, this should be the shallow dict of a GufeTokenizable.
+        Input of a GufeTokenizable will immediately return a base case.
+
+    Returns
+    -------
+    List[GufeTokenizable]
+        All GufeTokenizables found in the shallow dict representation of a
+        GufeTokenizable.
+
+    """
+    if is_gufe_obj(obj):
+        return [obj]
+
+    elif isinstance(obj, list):
+        return list(
+            chain.from_iterable([gufe_objects_from_shallow_dict(item) for item in obj])
+        )
+
+    elif isinstance(obj, dict):
+        return list(
+            chain.from_iterable(
+                [gufe_objects_from_shallow_dict(item) for item in obj.values()]
+            )
+        )
+
+    return []
+
+
+class KeyedChain(object):
+    """Keyed chain representation of a GufeTokenizable.
+
+    The keyed chain representation of a GufeTokenizable provides a
+    topologically sorted list of gufe keys and GufeTokenizable keyed dicts
+    that can be used to fully recreate a GufeTokenizable without the need for a
+    populated TOKENIZATION_REGISTRY.
+
+    The class wraps around a list of tuples containing the gufe key and the
+    keyed dict form of the GufeTokenizable.
+
+    """
+
+    def __init__(self, keyed_chain):
+        self._keyed_chain = keyed_chain
+
+    @classmethod
+    def from_gufe(cls, gufe_object: GufeTokenizable) -> super:
+        """Initialize a KeyedChain from a GufeTokenizable."""
+        return cls(cls.gufe_to_keyed_chain_rep(gufe_object))
+
+    def to_gufe(self) -> GufeTokenizable:
+        """Initialize a GufeTokenizable."""
+        gts = {}
+        for gufe_key, keyed_dict in self:
+            gt = key_decode_dependencies(keyed_dict, registry=gts)
+            gts[gufe_key] = gt
+        return gt
+
+    @staticmethod
+    def gufe_to_keyed_chain_rep(
+        gufe_object: GufeTokenizable,
+    ) -> List[Tuple[str, Dict]]:
+        """Create the keyed chain represenation of a GufeTokenizable.
+
+        This represents the GufeTokenizable as a list of two-element tuples
+        containing, as their first and second elements, the gufe key and keyed
+        dict form of the GufeTokenizable, respectively, and provides the
+        underlying structure used in the KeyedChain class.
+
+        Parameters
+        ----------
+        gufe_object
+            The GufeTokenizable for which the KeyedChain is generated.
+
+        Returns
+        -------
+        key_and_keyed_dicts
+            The keyed chain represenation of a GufeTokenizable.
+
+        """
+        key_and_keyed_dicts = [
+            (str(gt.key), gt.to_keyed_dict())
+            for gt in nx.topological_sort(gufe_to_digraph(gufe_object))
+        ][::-1]
+        return key_and_keyed_dicts
+
+    def gufe_keys(self) -> Generator[str, None, None]:
+        """Create a generator that iterates over the gufe keys in the KeyedChain."""
+        for key, _ in self:
+            yield key
+
+    def keyed_dicts(self) -> Generator[Dict, None, None]:
+        """Create a generator that iterates over the keyed dicts in the KeyedChain."""
+        for _, _dict in self:
+            yield _dict
+
+    def __len__(self):
+        return len(self._keyed_chain)
+
+    def __iter__(self):
+        return self._keyed_chain.__iter__()
+
+    def __getitem__(self, index):
+        return self._keyed_chain[index]
 
 
 # TOKENIZABLE_REGISTRY: Dict[str, weakref.ref[GufeTokenizable]] = {}

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -637,6 +637,48 @@ class GufeKey(str):
         """Unique hash of this key, typically a md5 value"""
         return self.split('-')[1]
 
+
+def gufe_objects_from_shallow_dict(
+    obj: Union[List, Dict, GufeTokenizable]
+) -> List[GufeTokenizable]:
+    """Find GufeTokenizables within a shallow dict.
+
+    This function recursively looks through the list/dict structures encoding
+    GufeTokenizables and returns list of all GufeTokenizables found
+    within those structures, which may be potentially nested.
+
+    Parameters
+    ----------
+    obj
+        The input data structure to recursively traverse. For the initial call
+        of this function, this should be the shallow dict of a GufeTokenizable.
+        Input of a GufeTokenizable will immediately return a base case.
+
+    Returns
+    -------
+    List[GufeTokenizable]
+        All GufeTokenizables found in the shallow dict representation of a
+        GufeTokenizable.
+
+    """
+    if is_gufe_obj(obj):
+        return [obj]
+
+    elif isinstance(obj, list):
+        return list(
+            chain.from_iterable([gufe_objects_from_shallow_dict(item) for item in obj])
+        )
+
+    elif isinstance(obj, dict):
+        return list(
+            chain.from_iterable(
+                [gufe_objects_from_shallow_dict(item) for item in obj.values()]
+            )
+        )
+
+    return []
+
+
 def gufe_to_digraph(gufe_obj):
     """Recursively construct a DiGraph from a GufeTokenizable.
 

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -14,7 +14,7 @@ import re
 import warnings
 import weakref
 from itertools import chain
-from typing import Any, Union, List, Tuple, Dict, Generator
+from typing import Any, Union, List, Tuple, Dict, Generator, Self
 
 from gufe.custom_codecs import (
     BYTES_CODEC,
@@ -663,7 +663,7 @@ def gufe_objects_from_shallow_dict(
         GufeTokenizable.
 
     """
-    if is_gufe_obj(obj):
+    if isinstance(obj, GufeTokenizable):
         return [obj]
 
     elif isinstance(obj, list):
@@ -736,13 +736,13 @@ class KeyedChain(object):
         self._keyed_chain = keyed_chain
 
     @classmethod
-    def from_gufe(cls, gufe_object: GufeTokenizable) -> super:
+    def from_gufe(cls, gufe_object: GufeTokenizable) -> Self:
         """Initialize a KeyedChain from a GufeTokenizable."""
         return cls(cls.gufe_to_keyed_chain_rep(gufe_object))
 
     def to_gufe(self) -> GufeTokenizable:
         """Initialize a GufeTokenizable."""
-        gts = {}
+        gts: Dict[str, GufeTokenizable] = {}
         for gufe_key, keyed_dict in self:
             gt = key_decode_dependencies(keyed_dict, registry=gts)
             gts[gufe_key] = gt

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -718,46 +718,6 @@ def gufe_to_digraph(gufe_obj):
 
     return graph
 
-def gufe_objects_from_shallow_dict(
-    obj: Union[List, Dict, GufeTokenizable]
-) -> List[GufeTokenizable]:
-    """Find GufeTokenizables within a shallow dict.
-
-    This function recursively looks through the list/dict structures encoding
-    GufeTokenizables and returns list of all GufeTokenizables found
-    within those structures, which may be potentially nested.
-
-    Parameters
-    ----------
-    obj
-        The input data structure to recursively traverse. For the initial call
-        of this function, this should be the shallow dict of a GufeTokenizable.
-        Input of a GufeTokenizable will immediately return a base case.
-
-    Returns
-    -------
-    List[GufeTokenizable]
-        All GufeTokenizables found in the shallow dict representation of a
-        GufeTokenizable.
-
-    """
-    if is_gufe_obj(obj):
-        return [obj]
-
-    elif isinstance(obj, list):
-        return list(
-            chain.from_iterable([gufe_objects_from_shallow_dict(item) for item in obj])
-        )
-
-    elif isinstance(obj, dict):
-        return list(
-            chain.from_iterable(
-                [gufe_objects_from_shallow_dict(item) for item in obj.values()]
-            )
-        )
-
-    return []
-
 
 class KeyedChain(object):
     """Keyed chain representation of a GufeTokenizable.


### PR DESCRIPTION
This PR implements the `KeyedChain` representation for `GufeTokenizable`s originally implemented in 
[alchemiscale](https://github.com/openforcefield/alchemiscale). As it appears general and useful enough, an upstream implementation seems appropriate.

The `KeyedChain` representation encodes a `GufeTokenizable` as a list of Tuples with the `GufeKey` and keyed dicts of other required tokenizables as their first and second elements, respectively. These tokenizables are sorted such that, when decoded in order, all required dependencies have been satisfied while accounting for duplicated dependencies down the tree structure. This representation is particularly useful when encoding/decoding `GufeTokenizables` on systems without a populated `TOKENIZATION_REGISTRY`.

- [x] Documentation
- [x] Tests