### PR TITLE
Add UUID JSON codec

### DIFF
--- a/gufe/custom_codecs.py
+++ b/gufe/custom_codecs.py
@@ -8,6 +8,7 @@ import pathlib
 
 import numpy as np
 from openff.units import DEFAULT_UNIT_REGISTRY
+from uuid import UUID
 
 import gufe
 from gufe.custom_json import JSONCodec
@@ -72,7 +73,6 @@ DATETIME_CODEC = JSONCodec(
     from_dict=lambda dct: datetime.datetime.fromisoformat(dct['isotime']),
 )
 
-
 # Note that this has inconsistent behaviour for some generic types
 # which end up being handled by the default JSON encoder/decoder.
 # The main example of this is np.float64 which will be turned into
@@ -136,4 +136,11 @@ OPENFF_UNIT_CODEC = JSONCodec(
     from_dict=lambda dct: DEFAULT_UNIT_REGISTRY(dct["unit_name"]).u,
     is_my_obj=lambda obj: isinstance(obj, DEFAULT_UNIT_REGISTRY.Unit),
     is_my_dict=is_openff_unit_dict,
+)
+
+
+UUID_CODEC = JSONCodec(
+    cls=UUID,
+    to_dict=lambda p: {"uuid": str(p)},
+    from_dict=lambda dct: UUID(dct["uuid"]),
 )

--- a/gufe/tests/test_custom_json.py
+++ b/gufe/tests/test_custom_json.py
@@ -11,7 +11,7 @@ import openff.units
 from openff.units import unit
 import pytest
 from numpy import testing as npt
-
+from uuid import uuid4
 from gufe.custom_codecs import (
     BYTES_CODEC,
     NUMPY_CODEC,
@@ -20,6 +20,7 @@ from gufe.custom_codecs import (
     OPENFF_UNIT_CODEC,
     PATH_CODEC,
     SETTINGS_CODEC,
+    UUID_CODEC,
 )
 from gufe.custom_json import JSONSerializerDeserializer, custom_json_factory
 from gufe import tokenization
@@ -297,5 +298,20 @@ class TestOpenFFUnitCodec(CustomJSONCodingTest):
                 ":is_custom:": True,
                 "pint_unit_registry": "openff_units",
                 "unit_name": "unified_atomic_mass_unit",
+            }
+        ]
+
+class TestUUIDCodec(CustomJSONCodingTest):
+    def setup_method(self):
+        self.codec = UUID_CODEC
+        self.objs = [
+            uuid4()
+        ]
+        self.dcts = [
+            {
+                ":is_custom:": True,
+                "__class__": "UUID",
+                "__module__": "uuid",
+                "uuid": f"{str(self.objs[0])}",
             }
         ]

--- a/gufe/tests/test_custom_json.py
+++ b/gufe/tests/test_custom_json.py
@@ -301,6 +301,7 @@ class TestOpenFFUnitCodec(CustomJSONCodingTest):
             }
         ]
 
+
 class TestUUIDCodec(CustomJSONCodingTest):
     def setup_method(self):
         self.codec = UUID_CODEC

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -23,6 +23,7 @@ from gufe.custom_codecs import (
     OPENFF_UNIT_CODEC,
     PATH_CODEC,
     SETTINGS_CODEC,
+    UUID_CODEC,
 )
 from gufe.custom_json import JSONSerializerDeserializer
 
@@ -35,6 +36,7 @@ _default_json_codecs = [
     SETTINGS_CODEC,
     OPENFF_UNIT_CODEC,
     OPENFF_QUANTITY_CODEC,
+    UUID_CODEC,
 ]
 JSON_HANDLER = JSONSerializerDeserializer(_default_json_codecs)
 


### PR DESCRIPTION
Adds a codec for serialising UUIDs inside GUFE objects when provided as instances of `uuid.UUID`

Fixes #293 