### PR TITLE
Update default off version to 2.1.1

### DIFF
--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -166,7 +166,7 @@ class OpenMMSystemGeneratorFFSettings(BaseForceFieldSettings):
     ]
     """List of force field paths for all components except :class:`SmallMoleculeComponent` """
 
-    small_molecule_forcefield: str = "openff-2.0.0"  # other default ideas 'openff-2.0.0', 'gaff-2.11', 'espaloma-0.2.0'
+    small_molecule_forcefield: str = "openff-2.1.1"  # other default ideas 'openff-2.0.0', 'gaff-2.11', 'espaloma-0.2.0'
     """Name of the force field to be used for :class:`SmallMoleculeComponent` """
 
     nonbonded_method = 'PME'

--- a/gufe/tests/test_alchemicalnetwork.py
+++ b/gufe/tests/test_alchemicalnetwork.py
@@ -13,8 +13,8 @@ from .test_tokenization import GufeTokenizableTestsMixin
 class TestAlchemicalNetwork(GufeTokenizableTestsMixin):
 
     cls = AlchemicalNetwork
-    key = "AlchemicalNetwork-c8978da28ad4b24f3a790853c9db2ee5"
-    repr = "<AlchemicalNetwork-c8978da28ad4b24f3a790853c9db2ee5>"
+    key = "AlchemicalNetwork-a6869a43fc26ab0b159dfee489616109"
+    repr = "<AlchemicalNetwork-a6869a43fc26ab0b159dfee489616109>"
 
     @pytest.fixture
     def instance(self, benzene_variants_star_map):

--- a/gufe/tests/test_custom_json.py
+++ b/gufe/tests/test_custom_json.py
@@ -219,7 +219,7 @@ class TestSettingsCodec(CustomJSONCodingTest):
                         "amber/tip3p_HFE_multivalent.xml",
                         "amber/phosaa10.xml",
                     ],
-                    "small_molecule_forcefield": "openff-2.0.0",
+                    "small_molecule_forcefield": "openff-2.1.1",
                     "nonbonded_method": "PME",
                     "nonbonded_cutoff": {':is_custom:': True,
                                          'magnitude': 1.0,

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -203,8 +203,8 @@ class BrokenProtocol(DummyProtocol):
 class TestProtocol(GufeTokenizableTestsMixin):
 
     cls = DummyProtocol
-    key = "DummyProtocol-140583b69a04f875265977f9e5f114d8"
-    repr = "<DummyProtocol-140583b69a04f875265977f9e5f114d8>"
+    key = "DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa"
+    repr = "<DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa>"
     @pytest.fixture
     def instance(self):
         return DummyProtocol(settings=DummyProtocol.default_settings())

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -31,8 +31,8 @@ def complex_equilibrium(solvated_complex):
 
 class TestTransformation(GufeTokenizableTestsMixin):
     cls = Transformation
-    key = "Transformation-2a94af9c426014a912d61ed5b19ca457"
-    repr = "Transformation(stateA=ChemicalSystem(name=, components={'ligand': SmallMoleculeComponent(name=toluene), 'solvent': SolventComponent(name=O, K+, Cl-)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-140583b69a04f875265977f9e5f114d8>)"
+    key = "Transformation-3e001d3eaa6eb0cb1a77f6460f3f6f29"
+    repr = "Transformation(stateA=ChemicalSystem(name=, components={'ligand': SmallMoleculeComponent(name=toluene), 'solvent': SolventComponent(name=O, K+, Cl-)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa>)"
 
     @pytest.fixture
     def instance(self, absolute_transformation):
@@ -141,8 +141,8 @@ class TestTransformation(GufeTokenizableTestsMixin):
 class TestNonTransformation(GufeTokenizableTestsMixin):
 
     cls = NonTransformation
-    key = "NonTransformation-943a2add20d0a1cc048e998f94ed6071"
-    repr = "NonTransformation(stateA=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-140583b69a04f875265977f9e5f114d8>)"
+    key = "NonTransformation-5fe8c396da48515ad75acc7cb5d02607"
+    repr = "NonTransformation(stateA=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa>)"
 
     @pytest.fixture
     def instance(self, complex_equilibrium):


### PR DESCRIPTION
Fixes #303 

@hannahbaumann has been benchmarking with 2.1.0, but 2.1.1 should be identical with just an additional set of parameters for Xe: https://github.com/openforcefield/openff-forcefields/releases/tag/2024.01.0