### PR TITLE
Adding a generic atom mapping scorer

### DIFF
--- a/gufe/__init__.py
+++ b/gufe/__init__.py
@@ -18,7 +18,7 @@ from .chemicalsystem import ChemicalSystem
 
 from .mapping import (
     ComponentMapping,  # how individual Components relate
-    AtomMapping, AtomMapper,  # more specific to atom based components
+    AtomMapping, AtomMapper,  AtomMappingScorer, # more specific to atom based components
     LigandAtomMapping,
 )
 

--- a/gufe/__init__.py
+++ b/gufe/__init__.py
@@ -18,7 +18,7 @@ from .chemicalsystem import ChemicalSystem
 
 from .mapping import (
     ComponentMapping,  # how individual Components relate
-    AtomMapping, AtomMapper,  AtomMappingScorer, # more specific to atom based components
+    AtomMapping, AtomMapper,  AtomMappingScorer,  # more specific to atom based components
     LigandAtomMapping,
 )
 

--- a/gufe/components/proteincomponent.py
+++ b/gufe/components/proteincomponent.py
@@ -59,7 +59,12 @@ _CHIRALITY_STR_TO_RDKIT = {
 
 
 negative_ions = ["F", "CL", "BR", "I"]
-positive_ions = ["NA", "MG", "CA", "ZN"]
+positive_ions = [
+    # +1
+    "LI", "NA", "K", "RB", "CS",
+    # +2
+    "BE", "MG", "CA", "SR", "BA", "RA", "ZN",
+]
 
 
 class ProteinComponent(ExplicitMoleculeComponent):

--- a/gufe/components/proteincomponent.py
+++ b/gufe/components/proteincomponent.py
@@ -223,15 +223,11 @@ class ProteinComponent(ExplicitMoleculeComponent):
             default_valence = periodicTable.GetDefaultValence(atomic_num)
 
             if connectivity == 0:  # ions:
-                if atom_name.upper() in positive_ions:
-                    fc = default_valence  # e.g. Sodium ions
-                elif atom_name.upper() in negative_ions:
-                    fc = - default_valence  # e.g. Chlorine ions
-                elif atom_name.strip(string.digits).upper() in positive_ions:
-                    # catches cases like 'CL1' as name
-                    fc = default_valence
+                # strip catches cases like 'CL1' as name
+                if atom_name.strip(string.digits).upper() in positive_ions:
+                    fc = default_valence   # e.g. Sodium ions
                 elif atom_name.strip(string.digits).upper() in negative_ions:
-                    fc = - default_valence
+                    fc = - default_valence  # e.g. Chlorine ions
                 else:  # -no-cov-
                     resn = a.GetMonomerInfo().GetResidueName()
                     resind = int(a.GetMonomerInfo().GetResidueNumber())

--- a/gufe/components/proteincomponent.py
+++ b/gufe/components/proteincomponent.py
@@ -5,6 +5,7 @@ import json
 import io
 import numpy as np
 from os import PathLike
+import string
 from typing import Union, Optional
 from collections import defaultdict
 
@@ -222,10 +223,15 @@ class ProteinComponent(ExplicitMoleculeComponent):
             default_valence = periodicTable.GetDefaultValence(atomic_num)
 
             if connectivity == 0:  # ions:
-                if atom_name in positive_ions:
+                if atom_name.upper() in positive_ions:
                     fc = default_valence  # e.g. Sodium ions
-                elif atom_name in negative_ions:
+                elif atom_name.upper() in negative_ions:
                     fc = - default_valence  # e.g. Chlorine ions
+                elif atom_name.strip(string.digits).upper() in positive_ions:
+                    # catches cases like 'CL1' as name
+                    fc = default_valence
+                elif atom_name.strip(string.digits).upper() in negative_ions:
+                    fc = - default_valence
                 else:  # -no-cov-
                     resn = a.GetMonomerInfo().GetResidueName()
                     resind = int(a.GetMonomerInfo().GetResidueNumber())

--- a/gufe/mapping/__init__.py
+++ b/gufe/mapping/__init__.py
@@ -4,4 +4,6 @@
 from .componentmapping import ComponentMapping
 from .atom_mapping import AtomMapping
 from .atom_mapper import AtomMapper
+from .atom_mapping_scorer import AtomMappingScorer
 from .ligandatommapping import LigandAtomMapping
+

--- a/gufe/mapping/__init__.py
+++ b/gufe/mapping/__init__.py
@@ -6,4 +6,3 @@ from .atom_mapping import AtomMapping
 from .atom_mapper import AtomMapper
 from .atom_mapping_scorer import AtomMappingScorer
 from .ligandatommapping import LigandAtomMapping
-

--- a/gufe/mapping/atom_mapping_scorer.py
+++ b/gufe/mapping/atom_mapping_scorer.py
@@ -1,0 +1,42 @@
+# This code is part of kartograf and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/gufe
+
+import abc
+
+from . import AtomMapping
+
+
+class AtomMappingScorer(abc.ABC):
+    """A generic class for scoring Atom mappings.
+    this class can be used for example to build graph algorithm based networks.
+
+    Implementations of this class can require an arbitrary and non-standardised
+    number of input arguments to create.
+
+    Implementations of this class provide the :meth:`.get_score` method
+
+    """
+
+    def __call__(self, mapping: AtomMapping, *args, **kwargs) -> float:
+        return self.get_score(mapping)
+
+    @abc.abstractmethod
+    def get_score(self, mapping: AtomMapping, *args, **kwargs) -> float:
+        """ calculate the score for an  :class:`.AtomMapping`
+            the scoring function returns a value between 0 and 1.
+            a value close to 1.0 indicates a small distance, a score close to zero indicates a large cost/error.
+
+        Parameters
+        ----------
+        mapping: AtomMapping
+            the mapping to be scored
+        args
+        kwargs
+
+        Returns
+        -------
+        float
+            a value between [0,1] where one is a very bad score and 0 a very good one.
+
+        """
+        pass

--- a/gufe/mapping/atom_mapping_scorer.py
+++ b/gufe/mapping/atom_mapping_scorer.py
@@ -17,11 +17,11 @@ class AtomMappingScorer(abc.ABC):
 
     """
 
-    def __call__(self, mapping: AtomMapping, *args, **kwargs) -> float:
+    def __call__(self, mapping: AtomMapping) -> float:
         return self.get_score(mapping)
 
     @abc.abstractmethod
-    def get_score(self, mapping: AtomMapping, *args, **kwargs) -> float:
+    def get_score(self, mapping: AtomMapping) -> float:
         """ calculate the score for an  :class:`.AtomMapping`
             the scoring function returns a value between 0 and 1.
             a value close to 1.0 indicates a small distance, a score close to zero indicates a large cost/error.

--- a/gufe/mapping/atom_mapping_scorer.py
+++ b/gufe/mapping/atom_mapping_scorer.py
@@ -25,7 +25,7 @@ class AtomMappingScorer(GufeTokenizable):
     def get_score(self, mapping: AtomMapping) -> float:
         """ calculate the score for an  :class:`.AtomMapping`
             the scoring function returns a value between 0 and 1.
-            a value close to 1.0 indicates a small distance, a score close to zero indicates a large cost/error.
+            a value close to 1.0 indicates a small change, a score close to zero indicates a large cost/change.
 
         Parameters
         ----------

--- a/gufe/mapping/atom_mapping_scorer.py
+++ b/gufe/mapping/atom_mapping_scorer.py
@@ -36,7 +36,7 @@ class AtomMappingScorer(abc.ABC):
         Returns
         -------
         float
-            a value between [0,1] where one is a very bad score and 0 a very good one.
+            a value between [0,1] where zero is a very bad score and one a very good one.
 
         """
         pass

--- a/gufe/mapping/atom_mapping_scorer.py
+++ b/gufe/mapping/atom_mapping_scorer.py
@@ -2,11 +2,12 @@
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
 import abc
+from ..tokenization import GufeTokenizable
 
 from . import AtomMapping
 
 
-class AtomMappingScorer(abc.ABC):
+class AtomMappingScorer(GufeTokenizable):
     """A generic class for scoring Atom mappings.
     this class can be used for example to build graph algorithm based networks.
 

--- a/gufe/tests/test_setup_interfaces.py
+++ b/gufe/tests/test_setup_interfaces.py
@@ -1,0 +1,14 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/gufe
+
+import pytest
+from gufe import AtomMappingScorer, AtomMapper
+
+
+def test_atom_mapping_scorer():
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMappingScorer without an implementation for abstract methods '_defaults', '_from_dict', '_to_dict', 'get_score'"):
+        scorer = AtomMappingScorer()
+
+def test_atom_mapper():
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper without an implementation for abstract methods '_defaults', '_from_dict', '_to_dict', 'suggest_mappings'"):
+        mapper = AtomMapper()

--- a/gufe/tests/test_setup_interfaces.py
+++ b/gufe/tests/test_setup_interfaces.py
@@ -6,9 +6,9 @@ from gufe import AtomMappingScorer, AtomMapper
 
 
 def test_atom_mapping_scorer():
-    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMappingScorer without an implementation for abstract methods '_defaults', '_from_dict', '_to_dict', 'get_score'"):
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper with abstract methods"):
         scorer = AtomMappingScorer()
 
 def test_atom_mapper():
-    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper without an implementation for abstract methods '_defaults', '_from_dict', '_to_dict', 'suggest_mappings'"):
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper without an implementation for abstract method"):
         mapper = AtomMapper()

--- a/gufe/tests/test_setup_interfaces.py
+++ b/gufe/tests/test_setup_interfaces.py
@@ -6,10 +6,10 @@ from gufe import AtomMappingScorer, AtomMapper
 
 
 def test_atom_mapping_scorer():
-    with pytest.raises(TypeError, match=""Can't instantiate abstract class AtomMappingScorer"):
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMappingScorer"):
         scorer = AtomMappingScorer()
 
 
 def test_atom_mapper():
-    with pytest.raises(TypeError, match=""Can't instantiate abstract class AtomMapper"):
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper"):
         mapper = AtomMapper()

--- a/gufe/tests/test_setup_interfaces.py
+++ b/gufe/tests/test_setup_interfaces.py
@@ -9,6 +9,7 @@ def test_atom_mapping_scorer():
     with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper with abstract methods"):
         scorer = AtomMappingScorer()
 
+
 def test_atom_mapper():
     with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper without an implementation for abstract method"):
         mapper = AtomMapper()

--- a/gufe/tests/test_setup_interfaces.py
+++ b/gufe/tests/test_setup_interfaces.py
@@ -6,10 +6,10 @@ from gufe import AtomMappingScorer, AtomMapper
 
 
 def test_atom_mapping_scorer():
-    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper with abstract methods"):
+    with pytest.raises(TypeError, match=""Can't instantiate abstract class AtomMappingScorer"):
         scorer = AtomMappingScorer()
 
 
 def test_atom_mapper():
-    with pytest.raises(TypeError, match="Can't instantiate abstract class AtomMapper without an implementation for abstract method"):
+    with pytest.raises(TypeError, match=""Can't instantiate abstract class AtomMapper"):
         mapper = AtomMapper()


### PR DESCRIPTION
this is a generic interface for all openFE scorers.

Todo:
- [x] define Interface
- [x] tests
- [x] tokenizable
- [x] User stories
- [x] Find Update places (LOMAP, Ruler, OpenFE-Setup, Example Scripts and Notebooks)

