### PR TITLE
Improve partial charge check

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -42,7 +42,8 @@ def _check_partial_charges(mol: RDKitMol) -> None:
     Checks for the presence of partial charges.
 
     Note:
-        We ensure the charges are set as atom properties as well to make sure they are detected by OpenFF
+        We ensure the charges are set as atom properties
+        to ensure they are detected by OpenFF
 
     Raises
     ------

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -78,6 +78,11 @@ def _check_partial_charges(mol: RDKitMol) -> None:
         atom = mol.GetAtomWithIdx(i)
         if not atom.HasProp("PartialCharge"):
             atom.SetDoubleProp("PartialCharge", charge)
+        else:
+            atom_charge = atom.GetDoubleProp("PartialCharge")
+            if not np.isclose(atom_charge, charge):
+                errmsg = f"non-equivalent partial charges between atom and molecule properties: {atom_charge} {charge}"
+                raise ValueError(errmsg)
 
     if np.all(np.isclose(p_chgs, 0.0)):
         wmsg = (f"Partial charges provided all equal to "

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -81,7 +81,8 @@ def _check_partial_charges(mol: RDKitMol) -> None:
         else:
             atom_charge = atom.GetDoubleProp("PartialCharge")
             if not np.isclose(atom_charge, charge):
-                errmsg = f"non-equivalent partial charges between atom and molecule properties: {atom_charge} {charge}"
+                errmsg = (f"non-equivalent partial charges between atom and "
+                          f"molecule properties: {atom_charge} {charge}")
                 raise ValueError(errmsg)
 
     if np.all(np.isclose(p_chgs, 0.0)):

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -41,6 +41,9 @@ def _check_partial_charges(mol: RDKitMol) -> None:
     """
     Checks for the presence of partial charges.
 
+    Note:
+        We ensure the charges are set as atom properties as well to make sure they are detected by OpenFF
+
     Raises
     ------
     ValueError
@@ -67,6 +70,12 @@ def _check_partial_charges(mol: RDKitMol) -> None:
         errmsg = (f"Sum of partial charges {sum(p_chgs)} differs from "
                   f"RDKit formal charge {Chem.GetFormalCharge(mol)}")
         raise ValueError(errmsg)
+
+    # set the charges on the atoms if not already set
+    for i, charge in enumerate(p_chgs):
+        atom = mol.GetAtomWithIdx(i)
+        if not atom.HasProp("PartialCharge"):
+            atom.SetDoubleProp("PartialCharge", charge)
 
     if np.all(np.isclose(p_chgs, 0.0)):
         wmsg = (f"Partial charges provided all equal to "

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -41,9 +41,10 @@ def _check_partial_charges(mol: RDKitMol) -> None:
     """
     Checks for the presence of partial charges.
 
-    Note:
-        We ensure the charges are set as atom properties
-        to ensure they are detected by OpenFF
+    Note
+    ----
+    We ensure the charges are set as atom properties
+    to ensure they are detected by OpenFF
 
     Raises
     ------

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -264,6 +264,23 @@ class TestSmallMoleculeComponentPartialCharges:
         with pytest.raises(ValueError, match="Incorrect number of"):
             SmallMoleculeComponent.from_rdkit(mol)
 
+    def test_partial_charges_applied_to_atoms(self):
+        """Make sure that charges set at the molecule level are transferred to atoms and picked up by openFF."""
+        mol = Chem.AddHs(Chem.MolFromSmiles("C"))
+        Chem.AllChem.Compute2DCoords(mol)
+        # add some fake charges at the molecule level
+        mol.SetProp('atom.dprop.PartialCharge', '-1 0.25 0.25 0.25 0.25')
+        matchmsg = "Partial charges have been provided"
+        with pytest.warns(UserWarning, match=matchmsg):
+            ofe = SmallMoleculeComponent.from_rdkit(mol)
+            # convert to openff and make sure the charges are set
+            off_mol = ofe.to_openff()
+            assert off_mol.partial_charges is not None
+            # check ordering is the same
+            rdkit_mol_with_charges = ofe.to_rdkit()
+            for i, charge in enumerate(off_mol.partial_charges.m):
+                assert rdkit_mol_with_charges.GetAtomWithIdx(i).GetDoubleProp("PartialCharge") == charge
+
 
 @pytest.mark.parametrize('mol, charge', [
     ('CC', 0), ('CC[O-]', -1),

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -298,7 +298,10 @@ class TestSmallMoleculeComponentPartialCharges:
         for atom in mol.GetAtoms():
             atom.SetDoubleProp("PartialCharge", 0)
 
-        with pytest.raises(ValueError, match="non-equivalent partial charges between atom and molecule properties"):
+        # make sure the correct error is raised
+        msg = ("non-equivalent partial charges between "
+               "atom and molecule properties")
+        with pytest.raises(ValueError, match=msg):
             SmallMoleculeComponent.from_rdkit(mol)
 
 

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -265,7 +265,10 @@ class TestSmallMoleculeComponentPartialCharges:
             SmallMoleculeComponent.from_rdkit(mol)
 
     def test_partial_charges_applied_to_atoms(self):
-        """Make sure that charges set at the molecule level are transferred to atoms and picked up by openFF."""
+        """
+        Make sure that charges set at the molecule level
+        are transferred to atoms and picked up by openFF.
+        """
         mol = Chem.AddHs(Chem.MolFromSmiles("C"))
         Chem.AllChem.Compute2DCoords(mol)
         # add some fake charges at the molecule level
@@ -273,13 +276,14 @@ class TestSmallMoleculeComponentPartialCharges:
         matchmsg = "Partial charges have been provided"
         with pytest.warns(UserWarning, match=matchmsg):
             ofe = SmallMoleculeComponent.from_rdkit(mol)
-            # convert to openff and make sure the charges are set
-            off_mol = ofe.to_openff()
-            assert off_mol.partial_charges is not None
-            # check ordering is the same
-            rdkit_mol_with_charges = ofe.to_rdkit()
-            for i, charge in enumerate(off_mol.partial_charges.m):
-                assert rdkit_mol_with_charges.GetAtomWithIdx(i).GetDoubleProp("PartialCharge") == charge
+        # convert to openff and make sure the charges are set
+        off_mol = ofe.to_openff()
+        assert off_mol.partial_charges is not None
+        # check ordering is the same
+        rdkit_mol_with_charges = ofe.to_rdkit()
+        for i, charge in enumerate(off_mol.partial_charges.m):
+            rdkit_atom = rdkit_mol_with_charges.GetAtomWithIdx(i)
+            assert rdkit_atom.GetDoubleProp("PartialCharge") == charge
 
 
 @pytest.mark.parametrize('mol, charge', [


### PR DESCRIPTION
This PR fixes #325 by ensuring user charges set at the molecule level are also set at the atom level which is how OpenFF detects them.