### PR TITLE
DNM Added Black formatting check action for GitHub

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,22 @@
+name: "Black formatting"
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: ./gufe


### PR DESCRIPTION
I've added a basic format checking action (using Black). This is *somewhat* related to #291, but this PR is for a GitHub action versus local commit hooks that are managing more than just formatting.

The addition of `pre-commit-config.yaml` in the PR linked above only appears useful locally, but I assume the plan is to hook into https://pre-commit.ci/ at some point since expecting new developers to always remember to install the hooks is unrealistic and thus unenforceable without checks like the one added in **this** PR. 

Generally, I'm in favor of keeping external services to a minimum, with particular emphasis on those that write commits. Alternatively, we can add individual actions for each check. It might instead make sense to maintain an OpenFreeEnergy Python package action that is easy to include in any new Python projects.

I'm setting this as DNM for now to give time for discussion. Thoughts @IAlibay @mikemhenry @dotsdl? Please ping others if you think they'd be interested!