### PR TITLE
Add to/from keyed chain methods to `GufeTokenizable`

### DIFF
--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -201,6 +201,21 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
             ':version:': 1,
         }
 
+        self.expected_keyed_chain = [
+            (str(leaf.key),
+             leaf_dict("foo")),
+            (str(bar.key),
+             leaf_dict({':gufe-key:': str(leaf.key)})),
+            (str(self.cont.key),
+             {':version:': 1,
+              '__module__': __name__,
+              '__qualname__': 'Container',
+              'dct': {'a': 'b',
+                      'leaf': {':gufe-key:': str(leaf.key)}},
+              'lst': [{':gufe-key:': str(leaf.key)}, 0],
+              'obj': {':gufe-key:': str(bar.key)}})
+        ]
+
     def test_set_key(self):
         leaf = Leaf("test-set-key")
         key = leaf.key
@@ -229,6 +244,14 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
 
     def test_from_keyed_dict(self):
         recreated = self.cls.from_keyed_dict(self.expected_keyed)
+        assert recreated == self.cont
+        assert recreated is self.cont
+
+    def test_to_keyed_chain(self):
+        assert self.cont.to_keyed_chain() == self.expected_keyed_chain
+
+    def test_from_keyed_chain(self):
+        recreated = self.cls.from_keyed_chain(self.expected_keyed_chain)
         assert recreated == self.cont
         assert recreated is self.cont
 

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -622,6 +622,41 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         dct.update(replacements)
         return self._from_dict(dct)
 
+    def to_keyed_chain(self) -> List[Tuple[str, Dict]]:
+        """
+        Create a minimal representation of the object using the key chain pattern.
+
+        Returns
+        -------
+        keyed_chain: List[Tuple[str, Dict]]
+            The keyed chain representation of a GufeTokenizable.
+
+        See Also
+        --------
+        KeyedChain
+        """
+        return KeyedChain.gufe_to_keyed_chain_rep(gufe_object=self)
+
+    @classmethod
+    def from_keyed_chain(cls, keyed_chain: List[Tuple[str, Dict]]):
+        """
+        Create an instance of the object from the keyed chain representation of the object.
+
+        Parameters
+        ----------
+        keyed_chain: List[Tuple[str, Dict]]
+            The keyed_chain representation of the GufeTokenizable.
+
+        Returns
+        -------
+            An instance of the serialised GufeTokenizable.
+
+        See Also
+        --------
+        KeyedChain
+        """
+        return KeyedChain.from_keyed_chain_rep(keyed_chain=keyed_chain).to_gufe()
+
 
 class GufeKey(str):
     def __repr__(self):   # pragma: no cover


### PR DESCRIPTION
Implements #361 by adding `to_keyed_chain` and a `from_keyed_chain` classmethod to GufeTokenizable. This should enable more compact serialisation options of GufeTokenizable objects throughout the ecosystem. 