### PR TITLE
JSON serialization on `GufeTokenizable`

### DIFF
--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -193,9 +193,9 @@ Similarly, you can reload the object with:
 .. code::
 
     import json
-    from gufe.tokenization import JSON_HANDLER
+    from gufe.tokenization import JSON_HANDLER, GufeTokenizable
     with open(filename, mode='r') as f:
-        obj = json.load(f, cls=JSON_HANDLER.decoder)
+        obj = GufeTokenizable.from_dict(json.load(f, cls=JSON_HANDLER.decoder))
 
 Note that these objects are not space-efficient: that is, if you have
 the same object in memory referenced by multiple objects (e.g., an identical
@@ -203,22 +203,31 @@ the same object in memory referenced by multiple objects (e.g., an identical
 save multiple copies of its JSON representation.
 
 On reloading, tools that use the recommended ``from_dict`` method will undo
-do this duplication; see :ref:`gufe-memory-deduplication` for details.
+this duplication; see :ref:`gufe-memory-deduplication` for details.
 
-Built in serialisation
-~~~~~~~~~~~~~~~~~~~~~~
+As a more space-efficient alternative to ``to_dict``/``from_dict``, consider
+using ``to_keyed_chain``/``from_keyed_chain`` instead.
+This deals in a representation using the :class:`.KeyedChain` approach, which
+avoids duplication of dependent :class:`.GufeTokenizables` in the serialized
+JSON representation.
 
-We also provide convince methods to convert any :class:`.GufeTokenizable` to and from JSON using a space-efficient
-serialisation strategy based on our :class:`.KeyedChain` representation. This is intended for developers that want to serialise
-these objects using the current best practice and are not concerned with the details of the process.
-The :func:`to_json <gufe.tokenization.GufeTokenizable.to_json>` API offers the flexibility to
+Convenient serialization
+~~~~~~~~~~~~------------
+
+We also provide convenience methods to convert any :class:`.GufeTokenizable` to
+and from JSON using a space-efficient serialization strategy based on our
+:class:`.KeyedChain` representation. This is intended for developers that want
+to serialise these objects using the current best practice and are not
+concerned with the details of the process. The :func:`to_json
+<gufe.tokenization.GufeTokenizable.to_json>` API offers the flexibility to
 convert to JSON directly or to write to a filelike object:
 
 .. code::
 
-    # get the json to save manually
+    # get a json representation in-memory
     json = obj.to_json()
-    # save to file directly
+
+    # save to a file directly
     obj.to_json(file=filename)
 
 Similarly, you can recreate the object using the :func:`from_json <gufe.tokenization.GufeTokenizable.from_json>`
@@ -226,9 +235,10 @@ classmethod:
 
 .. code::
 
-    # load the object from a file
+    # load the object from a json file produced with `to_json`
     obj = cls.from_json(file=filename)
-    # load from some json string
+
+    # load from a string produced with `to_json`
     obj = cls.from_json(content=json)
 
 

--- a/docs/guide/serialization.rst
+++ b/docs/guide/serialization.rst
@@ -205,6 +205,33 @@ save multiple copies of its JSON representation.
 On reloading, tools that use the recommended ``from_dict`` method will undo
 do this duplication; see :ref:`gufe-memory-deduplication` for details.
 
+Built in serialisation
+~~~~~~~~~~~~~~~~~~~~~~
+
+We also provide convince methods to convert any :class:`.GufeTokenizable` to and from JSON using a space-efficient
+serialisation strategy based on our :class:`.KeyedChain` representation. This is intended for developers that want to serialise
+these objects using the current best practice and are not concerned with the details of the process.
+The :func:`to_json <gufe.tokenization.GufeTokenizable.to_json>` API offers the flexibility to
+convert to JSON directly or to write to a filelike object:
+
+.. code::
+
+    # get the json to save manually
+    json = obj.to_json()
+    # save to file directly
+    obj.to_json(file=filename)
+
+Similarly, you can recreate the object using the :func:`from_json <gufe.tokenization.GufeTokenizable.from_json>`
+classmethod:
+
+.. code::
+
+    # load the object from a file
+    obj = cls.from_json(file=filename)
+    # load from some json string
+    obj = cls.from_json(content=json)
+
+
 .. Using JSON codecs outside of JSON
 .. ---------------------------------
 

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -257,18 +257,21 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
 
     def test_to_json_string(self):
         raw_json = self.cont.to_json()
+
         # tuples are converted to lists in JSON so fix the expected result to use lists
         expected_key_chain = [list(tok) for tok in self.expected_keyed_chain]
         assert json.loads(raw_json, cls=JSON_HANDLER.decoder) == expected_key_chain
 
     def test_from_json_string(self):
         recreated = self.cls.from_json(content=json.dumps(self.expected_keyed_chain, cls=JSON_HANDLER.encoder))
+
         assert recreated == self.cont
         assert recreated is self.cont
 
     def test_to_json_file(self, tmpdir):
         file_path = tmpdir / "container.json"
         self.cont.to_json(file=file_path)
+
         # tuples are converted to lists in JSON so fix the expected result to use lists
         expected_key_chain = [list(tok) for tok in self.expected_keyed_chain]
         assert json.load(file_path.open(mode="r"), cls=JSON_HANDLER.decoder) == expected_key_chain
@@ -277,6 +280,7 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         file_path = tmpdir / "container.json"
         json.dump(self.expected_keyed_chain, file_path.open(mode="w"), cls=JSON_HANDLER.encoder)
         recreated = self.cls.from_json(file=file_path)
+
         assert recreated == self.cont
         assert recreated is self.cont
 

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -255,6 +255,31 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         assert recreated == self.cont
         assert recreated is self.cont
 
+    def test_to_json_string(self):
+        raw_json = self.cont.to_json()
+        # tuples are converted to lists in JSON so fix the expected result to use lists
+        expected_key_chain = [list(tok) for tok in self.expected_keyed_chain]
+        assert json.loads(raw_json, cls=JSON_HANDLER.decoder) == expected_key_chain
+
+    def test_from_json_string(self):
+        recreated = self.cls.from_json(content=json.dumps(self.expected_keyed_chain, cls=JSON_HANDLER.encoder))
+        assert recreated == self.cont
+        assert recreated is self.cont
+
+    def test_to_json_file(self, tmpdir):
+        file_path = tmpdir / "container.json"
+        self.cont.to_json(file=file_path)
+        # tuples are converted to lists in JSON so fix the expected result to use lists
+        expected_key_chain = [list(tok) for tok in self.expected_keyed_chain]
+        assert json.load(file_path.open(mode="r"), cls=JSON_HANDLER.decoder) == expected_key_chain
+
+    def test_from_json_file(self, tmpdir):
+        file_path = tmpdir / "container.json"
+        json.dump(self.expected_keyed_chain, file_path.open(mode="w"), cls=JSON_HANDLER.encoder)
+        recreated = self.cls.from_json(file=file_path)
+        assert recreated == self.cont
+        assert recreated is self.cont
+
     def test_to_shallow_dict(self):
         assert self.cont.to_shallow_dict() == self.expected_shallow
 

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -201,6 +201,21 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
             ':version:': 1,
         }
 
+        self.expected_keyed_chain = [
+            (str(leaf.key),
+             leaf_dict("foo")),
+            (str(bar.key),
+             leaf_dict({':gufe-key:': str(leaf.key)})),
+            (str(self.cont.key),
+             {':version:': 1,
+              '__module__': __name__,
+              '__qualname__': 'Container',
+              'dct': {'a': 'b',
+                      'leaf': {':gufe-key:': str(leaf.key)}},
+              'lst': [{':gufe-key:': str(leaf.key)}, 0],
+              'obj': {':gufe-key:': str(bar.key)}})
+        ]
+
     def test_set_key(self):
         leaf = Leaf("test-set-key")
         key = leaf.key
@@ -229,6 +244,14 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
 
     def test_from_keyed_dict(self):
         recreated = self.cls.from_keyed_dict(self.expected_keyed)
+        assert recreated == self.cont
+        assert recreated is self.cont
+
+    def test_to_keyed_chain(self):
+        assert self.cont.to_keyed_chain() == self.expected_keyed_chain
+
+    def test_from_keyed_chain(self):
+        recreated = self.cls.from_keyed_chain(self.expected_keyed_chain)
         assert recreated == self.cont
         assert recreated is self.cont
 

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -14,7 +14,8 @@ import re
 import warnings
 import weakref
 from itertools import chain
-from typing import Any, Union, List, Tuple, Dict, Generator
+from os import PathLike
+from typing import Any, Union, List, Tuple, Dict, Generator, TextIO
 from typing_extensions import Self
 
 from gufe.custom_codecs import (
@@ -648,7 +649,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         """
         return KeyedChain(keyed_chain=keyed_chain).to_gufe()
 
-    def to_json(self, file=None) -> None | str:
+    def to_json(self, file: PathLike | TextIO = None) -> None | str:
         """
         Generate a JSON keyed chain representation.
 
@@ -677,14 +678,18 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
             json.dump(self.to_keyed_chain(), out, cls=JSON_HANDLER.encoder)
 
     @classmethod
-    def from_json(cls, content=None, file=None):
+    def from_json(cls, file: PathLike | TextIO = None, content: str = None):
         """
         Generate an instance from JSON keyed chain representation.
+
+        Can provide either a filepath/filelike as `file`, or JSON content via `content`.
 
         Parameters
         ----------
         file
             A filepath or filelike object to read JSON data from.
+        content
+            A string to read JSON data from.
 
         See Also
         --------

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -677,7 +677,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         with ensure_filelike(file, mode="w") as out:
             json.dump(self.to_keyed_chain(), out, cls=JSON_HANDLER.encoder)
 
-        return
+        return None
 
     @classmethod
     def from_json(cls, file: Optional[PathLike | TextIO] = None, content: Optional[str] = None):

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -657,6 +657,51 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         """
         return KeyedChain.from_keyed_chain_rep(keyed_chain=keyed_chain).to_gufe()
 
+    def to_json(self, file=None) -> None | str:
+        """
+        Create a minimal JSON representation of a GufeTokenizable using the keyed chain pattern.
+
+        This will be writen to the file like object if passed.
+
+        Parameters
+        ----------
+        file: Optional
+            A file or file like object to write the JSON to.
+
+        Returns
+        -------
+        A minimal JSON representation of the object if no file is supped else None.
+
+        See Also
+        --------
+        from_json
+        """
+        json_data = json.dumps(self.to_keyed_chain(), cls=JSON_HANDLER.encoder)
+        if file is None:
+            return json_data
+
+        from gufe.utils import ensure_filelike
+        with ensure_filelike(file, mode="w") as out:
+            out.write(json_data)
+
+    @classmethod
+    def from_json(cls, file):
+        """
+        Create a GufeTokenizable from the minimal JSON representation created using the keyed chain pattern.
+
+        Parameters
+        ----------
+        file:
+            The file like object the JSON is stored in.
+
+        See Also
+        --------
+        to_json
+        """
+        from gufe.utils import ensure_filelike
+        with ensure_filelike(file, mode="r") as f:
+            keyed_chain = json.load(f, cls=JSON_HANDLER.decoder)
+        return cls.from_keyed_chain(keyed_chain=keyed_chain)
 
 class GufeKey(str):
     def __repr__(self):   # pragma: no cover

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -15,7 +15,7 @@ import warnings
 import weakref
 from itertools import chain
 from os import PathLike
-from typing import Any, Union, List, Tuple, Dict, Generator, TextIO
+from typing import Any, Union, List, Tuple, Dict, Generator, TextIO, Optional
 from typing_extensions import Self
 
 from gufe.custom_codecs import (
@@ -649,7 +649,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         """
         return KeyedChain(keyed_chain=keyed_chain).to_gufe()
 
-    def to_json(self, file: PathLike | TextIO = None) -> None | str:
+    def to_json(self, file: Optional[PathLike | TextIO] = None) -> None | str:
         """
         Generate a JSON keyed chain representation.
 
@@ -677,8 +677,10 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         with ensure_filelike(file, mode="w") as out:
             json.dump(self.to_keyed_chain(), out, cls=JSON_HANDLER.encoder)
 
+        return
+
     @classmethod
-    def from_json(cls, file: PathLike | TextIO = None, content: str = None):
+    def from_json(cls, file: Optional[PathLike | TextIO] = None, content: Optional[str] = None):
         """
         Generate an instance from JSON keyed chain representation.
 

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -622,6 +622,41 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         dct.update(replacements)
         return self._from_dict(dct)
 
+    def to_keyed_chain(self) -> List[Tuple[str, Dict]]:
+        """
+        Create a minimal representation of the object using the key chain pattern.
+
+        Returns
+        -------
+        keyed_chain: List[Tuple[str, Dict]]
+            The keyed chain representation of a GufeTokenizable.
+
+        See Also
+        --------
+        KeyedChain
+        """
+        return KeyedChain.gufe_to_keyed_chain_rep(gufe_object=self)
+
+    @classmethod
+    def from_keyed_chain(cls, keyed_chain: List[Tuple[str, Dict]]):
+        """
+        Create an instance of the object from the keyed chain representation of the object.
+
+        Parameters
+        ----------
+        keyed_chain: List[Tuple[str, Dict]]
+            The keyed_chain representation of the GufeTokenizable.
+
+        Returns
+        -------
+            An instance of the serialised GufeTokenizable.
+
+        See Also
+        --------
+        KeyedChain
+        """
+        return KeyedChain.from_keyed_chain_rep(keyed_chain=keyed_chain).to_gufe()
+
 
 class GufeKey(str):
     def __repr__(self):   # pragma: no cover


### PR DESCRIPTION
Implements #359.

This adds convenience methods to the `GufeTokenizable` class to aid easy serialisation to and from JSON using the `keyed_chain` pattern which keeps the JSON objects small. 

# Questions
@dotsdl I like the idea of having a serialisation module but noticed I would have to move the `JSON_HANDLER` which is a large API break so I went for the easier option for now. 

For the `from_json` method I wasn't quite sure how to handle filelike vs  JSON object input, Do you have any ideas? 

I noticed the [Transformation](https://docs.openfree.energy/en/stable/cookbook/dumping_transformation.html) object has saving and loading from JSON already with its `dump/load` methods do we want to keep these and route them through the new `to/from_json` methods and remove them later?

If we are happy with this I'll add some tests. 