### PR TITLE
Removed all hardcoded gufe keys from GufeTokenizable tests in test suite

### DIFF
--- a/gufe/tests/test_alchemicalnetwork.py
+++ b/gufe/tests/test_alchemicalnetwork.py
@@ -13,8 +13,7 @@ from .test_tokenization import GufeTokenizableTestsMixin
 class TestAlchemicalNetwork(GufeTokenizableTestsMixin):
 
     cls = AlchemicalNetwork
-    key = "AlchemicalNetwork-a6869a43fc26ab0b159dfee489616109"
-    repr = "<AlchemicalNetwork-a6869a43fc26ab0b159dfee489616109>"
+    repr = None
 
     @pytest.fixture
     def instance(self, benzene_variants_star_map):

--- a/gufe/tests/test_chemicalsystem.py
+++ b/gufe/tests/test_chemicalsystem.py
@@ -118,7 +118,6 @@ def test_sorting(solvated_complex, solvated_ligand):
 class TestChemicalSystem(GufeTokenizableTestsMixin):
 
     cls = ChemicalSystem
-    key = "ChemicalSystem-92176395ceb86ecd7787ce2585b24218"
     repr = "ChemicalSystem(name=, components={'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)})"
 
     @pytest.fixture

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -129,8 +129,7 @@ def network_container(
 
 class TestLigandNetwork(GufeTokenizableTestsMixin):
     cls = LigandNetwork
-    key = "LigandNetwork-c597016564f85a3c42445bd1dabd91b3"
-    repr = "<LigandNetwork-c597016564f85a3c42445bd1dabd91b3>"
+    repr = None
 
     @pytest.fixture
     def instance(self, simple_network):

--- a/gufe/tests/test_ligandatommapping.py
+++ b/gufe/tests/test_ligandatommapping.py
@@ -275,7 +275,6 @@ class TestLigandAtomMappingBoundsChecks:
 class TestLigandAtomMapping(GufeTokenizableTestsMixin):
     cls = LigandAtomMapping
     repr = "LigandAtomMapping(componentA=SmallMoleculeComponent(name=), componentB=SmallMoleculeComponent(name=), componentA_to_componentB={0: 0, 1: 1}, annotations={'foo': 'bar'})"
-    key = "LigandAtomMapping-2c0aae226e3f69d2d1cf429abaefdb5b"
 
     @pytest.fixture
     def instance(self, annotated_simple_mapping):

--- a/gufe/tests/test_mapping.py
+++ b/gufe/tests/test_mapping.py
@@ -47,7 +47,6 @@ class ExampleMapping(AtomMapping):
 
 class TestMappingAbstractClass(GufeTokenizableTestsMixin):
     cls = ExampleMapping
-    key = 'ExampleMapping-ea9e102cdfddb0e243bde58074dd729c'
     repr = None
 
     @pytest.fixture

--- a/gufe/tests/test_proteincomponent.py
+++ b/gufe/tests/test_proteincomponent.py
@@ -87,7 +87,6 @@ def assert_topology_equal(ref_top, top):
 class TestProteinComponent(GufeTokenizableTestsMixin):
 
     cls = ProteinComponent
-    key = "ProteinComponent-089f72c9fa2c9c18d53308038eeab5c9"
     repr = "ProteinComponent(name=Steve)"
 
     @pytest.fixture

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -203,8 +203,8 @@ class BrokenProtocol(DummyProtocol):
 class TestProtocol(GufeTokenizableTestsMixin):
 
     cls = DummyProtocol
-    key = "DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa"
-    repr = "<DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa>"
+    repr = None
+
     @pytest.fixture
     def instance(self):
         return DummyProtocol(settings=DummyProtocol.default_settings())
@@ -374,7 +374,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
 
     class TestProtocolDAG(ProtocolDAGTestsMixin):
         cls = ProtocolDAG
-        key = None
         repr = None
 
         @pytest.fixture
@@ -384,7 +383,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
 
     class TestProtocolDAGResult(ProtocolDAGTestsMixin):
         cls = ProtocolDAGResult
-        key = None
         repr = None
 
         @pytest.fixture
@@ -436,7 +434,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
 
     class TestProtocolDAGResultFailure(ProtocolDAGTestsMixin):
         cls = ProtocolDAGResult
-        key = None
         repr = None
 
         @pytest.fixture
@@ -466,7 +463,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
 
     class TestProtocolUnit(GufeTokenizableTestsMixin):
         cls = SimulationUnit
-        key = None
         repr = None
     
         @pytest.fixture

--- a/gufe/tests/test_protocolresult.py
+++ b/gufe/tests/test_protocolresult.py
@@ -17,8 +17,7 @@ class DummyProtocolResult(gufe.ProtocolResult):
 
 class TestProtocolResult(GufeTokenizableTestsMixin):
     cls = DummyProtocolResult
-    key = 'DummyProtocolResult-b7b854b39c1e37feabec58b4000680a0'
-    repr = f'<{key}>'
+    repr = None
 
     @pytest.fixture
     def instance(self):

--- a/gufe/tests/test_serialization_migration.py
+++ b/gufe/tests/test_serialization_migration.py
@@ -176,21 +176,18 @@ class TestKeyAdded(MigrationTester):
     cls = KeyAdded
     input_dict = _SERIALIZED_OLD
     kwargs = {"foo": "foo", "bar": "bar", "qux": 10}
-    key = "KeyAdded-43d61e49c793a863b8b4f96b0e0b2876"
 
 
 class TestKeyRemoved(MigrationTester):
     cls = KeyRemoved
     input_dict = _SERIALIZED_OLD
     kwargs = {"foo": "foo"}
-    key = "KeyRemoved-93a689cdf75976b83507e4d1ded1ad7b"
 
 
 class TestKeyRenamed(MigrationTester):
     cls = KeyRenamed
     input_dict = _SERIALIZED_OLD
     kwargs = {"foo": "foo", "baz": "bar"}
-    key = "KeyRenamed-55860190714f16df7b9b6aab47346619"
 
 
 # for some reason, we'll move the child from belonging to the son to
@@ -256,7 +253,6 @@ class TestNestedKeyMoved(MigrationTester):
     kwargs = {
         'settings': {'son': {}, 'daughter': {'daughter_child': 10}}
     }
-    key = "Grandparent-0e2ea10e853d7ac730e7b2ae477a3801"
 
     @pytest.fixture
     def instance(self):

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -72,7 +72,6 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 class TestSmallMoleculeComponent(GufeTokenizableTestsMixin):
 
     cls = SmallMoleculeComponent
-    key = "SmallMoleculeComponent-82d90fcdcbe76a4155b0ea42b9080ff2"
     repr = "SmallMoleculeComponent(name=ethane)"
 
     @pytest.fixture

--- a/gufe/tests/test_solvents.py
+++ b/gufe/tests/test_solvents.py
@@ -81,7 +81,6 @@ def test_bad_inputs(pos, neg):
 class TestSolventComponent(GufeTokenizableTestsMixin):
 
     cls = SolventComponent
-    key = "SolventComponent-26b4034ad9dbd9f908dfc298ea8d449f"
     repr = "SolventComponent(name=O, Na+, Cl-)"
 
     @pytest.fixture

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -82,7 +82,6 @@ class GufeTokenizableTestsMixin(abc.ABC):
 
     # set this to the `GufeTokenizable` subclass you are testing
     cls: type[GufeTokenizable]
-    key: Optional[str]
     repr: Optional[str]
 
     @pytest.fixture
@@ -139,9 +138,6 @@ class GufeTokenizableTestsMixin(abc.ABC):
         # include `np.nan`s
         #assert ser == reser
 
-    def test_key_stable(self, instance):
-        assert self.key == instance.key
-
     def test_repr(self, instance):
         if self.repr is None:
             # nondeterministic reprs
@@ -153,7 +149,6 @@ class GufeTokenizableTestsMixin(abc.ABC):
 class TestGufeTokenizable(GufeTokenizableTestsMixin):
 
     cls = Container
-    key = "Container-3fcec08974fbbd0371fed8a185628b70"
     repr = "Container(Leaf(Leaf(foo, 2), 2), [Leaf(foo, 2), 0], {'leaf': Leaf(foo, 2), 'a': 'b'})"
 
     @pytest.fixture

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -139,6 +139,16 @@ class GufeTokenizableTestsMixin(abc.ABC):
         # include `np.nan`s
         #assert ser == reser
 
+    def test_key_stable(self, instance):
+        """Check that generating the instance from a dict representation yields
+        the same key (and the same instance).
+
+        """
+        instance_ = GufeTokenizable.from_dict(instance.to_dict())
+
+        assert instance_.key == instance.key
+        assert instance_ is instance
+
     def test_repr(self, instance):
         if self.repr is None:
             # nondeterministic reprs

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -31,7 +31,6 @@ def complex_equilibrium(solvated_complex):
 
 class TestTransformation(GufeTokenizableTestsMixin):
     cls = Transformation
-    key = "Transformation-3e001d3eaa6eb0cb1a77f6460f3f6f29"
     repr = "Transformation(stateA=ChemicalSystem(name=, components={'ligand': SmallMoleculeComponent(name=toluene), 'solvent': SolventComponent(name=O, K+, Cl-)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa>)"
 
     @pytest.fixture
@@ -141,7 +140,6 @@ class TestTransformation(GufeTokenizableTestsMixin):
 class TestNonTransformation(GufeTokenizableTestsMixin):
 
     cls = NonTransformation
-    key = "NonTransformation-5fe8c396da48515ad75acc7cb5d02607"
     repr = "NonTransformation(stateA=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-d01baed9cf2500c393bd6ddb35ee38aa>)"
 
     @pytest.fixture


### PR DESCRIPTION
We do not consider `gufe` keys to be stable across versions, though they should be stable in-process and generally across machines running the same software versions. We only rely on them being stable in-process, however.
