### PR TITLE
Add `AtomMappingError`

### DIFF
--- a/gufe/mapping/__init__.py
+++ b/gufe/mapping/__init__.py
@@ -4,4 +4,5 @@
 from .atom_mapper import AtomMapper
 from .atom_mapping import AtomMapping
 from .componentmapping import ComponentMapping
+from .errors import AtomMappingError
 from .ligandatommapping import LigandAtomMapping

--- a/gufe/mapping/errors.py
+++ b/gufe/mapping/errors.py
@@ -1,0 +1,5 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/gufe
+
+class AtomMappingError(Exception):
+    """Error when an atom mapping could not be created."""

--- a/gufe/mapping/errors.py
+++ b/gufe/mapping/errors.py
@@ -1,5 +1,6 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
+
 class AtomMappingError(Exception):
     """Error when an atom mapping could not be created."""


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #419. This error should be raised by the derived atom mappers when there is an issue generating mappings.
<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
