### PR TITLE
Remove PR trigger from conda_cron

### DIFF
--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -5,9 +5,6 @@ on:
   schedule:
     # At 07:00 UTC every day
     - cron: "0 7 * * *"
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"


### PR DESCRIPTION
I think we accidentally left the PR trigger from this action - it should only be run as a CRON job and never on PRs/merge.