### PR TITLE
Added deprecation warning to Transformation.dump/load; removed ExplicitMoleculeComponent.to_json/from_json

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -160,15 +160,6 @@ class ExplicitMoleculeComponent(Component):
         """Return an RDKit copied representation of this molecule"""
         return Chem.Mol(self._rdkit)
 
-    def to_json(self):
-        return json.dumps(self.to_dict())
-
-    # From
-    @classmethod
-    def from_json(cls, json_str):
-        dct = json.loads(json_str)
-        return cls.from_dict(dct)
-
     @classmethod
     def from_rdkit(cls, rdkit: RDKitMol, name: str = ""):
         """Create a Component, copying from an RDKit Mol"""

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -311,6 +311,20 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         assert recreated == self.cont
         assert recreated is self.cont
 
+    def test_from_json_file_dict(self, tmpdir):
+        """Test that we can still load json-serialized dict representations from files."""
+        file_path = tmpdir / "container.json"
+        json.dump(
+            self.expected_deep,
+            file_path.open(mode="w"),
+            cls=JSON_HANDLER.encoder,
+        )
+        with pytest.warns(UserWarning, match="keyed-chain deserialization failed"):
+            recreated = self.cls.from_json(file=file_path)
+
+        assert recreated == self.cont
+        assert recreated is self.cont
+
     def test_to_shallow_dict(self):
         assert self.cont.to_shallow_dict() == self.expected_shallow
 

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -283,7 +283,7 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         assert recreated == self.cont
         assert recreated is self.cont
 
-    def test_from_json_dict(self):
+    def test_from_json_string_dict(self):
         """Test that we can still load json-serialized dict representations."""
         with pytest.warns(UserWarning, match="keyed-chain deserialization failed"):
             recreated = self.cls.from_json(content=json.dumps(self.expected_deep, cls=JSON_HANDLER.encoder))

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -283,6 +283,16 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         assert recreated == self.cont
         assert recreated is self.cont
 
+    def test_from_json_dict(self):
+        """Test that we can still load json-serialized dict representations.
+
+        """
+        with pytest.warns(UserWarning, match="keyed-chain deserialization failed"):
+            recreated = self.cls.from_json(content=json.dumps(self.expected_deep, cls=JSON_HANDLER.encoder))
+
+        assert recreated == self.cont
+        assert recreated is self.cont
+
     def test_to_json_file(self, tmpdir):
         file_path = tmpdir / "container.json"
         self.cont.to_json(file=file_path)

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -284,9 +284,7 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         assert recreated is self.cont
 
     def test_from_json_dict(self):
-        """Test that we can still load json-serialized dict representations.
-
-        """
+        """Test that we can still load json-serialized dict representations."""
         with pytest.warns(UserWarning, match="keyed-chain deserialization failed"):
             recreated = self.cls.from_json(content=json.dumps(self.expected_deep, cls=JSON_HANDLER.encoder))
 

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -122,9 +122,11 @@ class TestTransformation(GufeTokenizableTestsMixin):
 
     def test_dump_load_roundtrip(self, absolute_transformation):
         string = io.StringIO()
-        absolute_transformation.dump(string)
+        with pytest.warns(DeprecationWarning, match="use of this method is deprecated; instead use `to_json`"):
+            absolute_transformation.dump(string)
         string.seek(0)
-        recreated = Transformation.load(string)
+        with pytest.warns(DeprecationWarning, match="use of this method is deprecated; instead use `from_json`"):
+            recreated = Transformation.load(string)
         assert absolute_transformation == recreated
 
     def test_deprecation_warning_on_dict_mapping(self, solvated_ligand, solvated_complex):

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -705,15 +705,23 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
             raise ValueError("Must specify either `content` and `file` for JSON input")
 
         if content is not None:
-            keyed_chain = json.loads(content, cls=JSON_HANDLER.decoder)
-            return cls.from_keyed_chain(keyed_chain=keyed_chain)
+            deserialized = json.loads(content, cls=JSON_HANDLER.decoder)
+            try:
+                return cls.from_keyed_chain(keyed_chain=deserialized)
+            except:
+                # if the above fails, try to load as the dict representation
+                return cls.from_dict(deserialized)
 
         from gufe.utils import ensure_filelike
 
         with ensure_filelike(file, mode="r") as f:
-            keyed_chain = json.load(f, cls=JSON_HANDLER.decoder)
+            deserialized = json.load(f, cls=JSON_HANDLER.decoder)
 
-        return cls.from_keyed_chain(keyed_chain=keyed_chain)
+        try:
+            return cls.from_keyed_chain(keyed_chain=deserialized)
+        except:
+            # if the above fails, try to load as the dict representation
+            return cls.from_dict(deserialized)
 
 
 class GufeKey(str):

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -710,9 +710,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
                 return cls.from_keyed_chain(keyed_chain=deserialized)
             except ValueError:
                 # if the above fails, try to load as the dict representation
-                warnings.warn(
-                    f"keyed-chain deserialization failed; falling back to deserializing dict representation"
-                )
+                warnings.warn(f"keyed-chain deserialization failed; falling back to deserializing dict representation")
                 return cls.from_dict(deserialized)
 
         from gufe.utils import ensure_filelike

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -722,9 +722,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
             return cls.from_keyed_chain(keyed_chain=deserialized)
         except ValueError:
             # if the above fails, try to load as the dict representation
-            warnings.warn(
-                f"keyed-chain deserialization failed; falling back to deserializing dict representation"
-            )
+            warnings.warn(f"keyed-chain deserialization failed; falling back to deserializing dict representation")
             return cls.from_dict(deserialized)
 
 

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -708,8 +708,11 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
             deserialized = json.loads(content, cls=JSON_HANDLER.decoder)
             try:
                 return cls.from_keyed_chain(keyed_chain=deserialized)
-            except:
+            except ValueError:
                 # if the above fails, try to load as the dict representation
+                warnings.warn(
+                    f"keyed-chain deserialization failed; falling back to deserializing dict representation"
+                )
                 return cls.from_dict(deserialized)
 
         from gufe.utils import ensure_filelike

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -720,8 +720,11 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
 
         try:
             return cls.from_keyed_chain(keyed_chain=deserialized)
-        except:
+        except ValueError:
             # if the above fails, try to load as the dict representation
+            warnings.warn(
+                f"keyed-chain deserialization failed; falling back to deserializing dict representation"
+            )
             return cls.from_dict(deserialized)
 
 

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -121,6 +121,10 @@ class TransformationBase(GufeTokenizable):
         file : Union[PathLike, FileLike]
             A pathlike of filelike to save this transformation to.
         """
+        warnings.warn(
+            ("use of this method is deprecated, " "instead use `to_json`"),
+            DeprecationWarning,
+        )
         with ensure_filelike(file, mode="w") as f:
             json.dump(self.to_dict(), f, cls=JSON_HANDLER.encoder, sort_keys=True)
 
@@ -133,6 +137,10 @@ class TransformationBase(GufeTokenizable):
         file : Union[PathLike, FileLike]
             A pathlike or filelike to read this transformation from.
         """
+        warnings.warn(
+            ("use of this method is deprecated, " "instead use `from_json`"),
+            DeprecationWarning,
+        )
         with ensure_filelike(file, mode="r") as f:
             dct = json.load(f, cls=JSON_HANDLER.decoder)
 

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -122,7 +122,7 @@ class TransformationBase(GufeTokenizable):
             A pathlike of filelike to save this transformation to.
         """
         warnings.warn(
-            ("use of this method is deprecated, " "instead use `to_json`"),
+            ("use of this method is deprecated; instead use `to_json`"),
             DeprecationWarning,
         )
         with ensure_filelike(file, mode="w") as f:
@@ -138,7 +138,7 @@ class TransformationBase(GufeTokenizable):
             A pathlike or filelike to read this transformation from.
         """
         warnings.warn(
-            ("use of this method is deprecated, " "instead use `from_json`"),
+            ("use of this method is deprecated; instead use `from_json`"),
             DeprecationWarning,
         )
         with ensure_filelike(file, mode="r") as f:
@@ -186,7 +186,7 @@ class Transformation(TransformationBase):
         """
         if isinstance(mapping, dict):
             warnings.warn(
-                ("mapping input as a dict is deprecated, " "instead use either a single Mapping or list"),
+                ("mapping input as a dict is deprecated; instead use either a single Mapping or list"),
                 DeprecationWarning,
             )
             mapping = list(mapping.values())

--- a/news/serialization-harmonization.rst
+++ b/news/serialization-harmonization.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``GufeTokenizable.from_json`` now falls back to loading ``dict`` representation if from ``keyed_chain`` fails
+
+**Deprecated:**
+
+* ``Transformation.dump``, ``Transformation.load`` are now deprecated
+
+**Removed:**
+
+* ``ExplicitMolecule.to_json``, ``ExplicitMolecule.from_json`` removed; now uses ``GufeTokenizable`` methods
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/serialization-harmonization.rst
+++ b/news/serialization-harmonization.rst
@@ -8,7 +8,7 @@
 
 **Deprecated:**
 
-* ``Transformation.dump``, ``Transformation.load`` are now deprecated
+* ``Transformation.dump``, ``Transformation.load`` are now deprecated, use Transformation.to_json and Transformation.from_json instead
 
 **Removed:**
 

--- a/news/serialization-harmonization.rst
+++ b/news/serialization-harmonization.rst
@@ -5,14 +5,15 @@
 **Changed:**
 
 * ``GufeTokenizable.from_json`` now falls back to loading ``dict`` representation if from ``keyed_chain`` fails
+* ``ExplicitMoleculeComponent`` now uses ``GufeTokenizable`` ``to_json`` and ``from_json`` methods via inheritance
 
 **Deprecated:**
 
-* ``Transformation.dump``, ``Transformation.load`` are now deprecated, use Transformation.to_json and Transformation.from_json instead
+* ``Transformation.dump``, ``Transformation.load`` are now deprecated, use ``Transformation.to_json`` and ``Transformation.from_json`` instead
 
 **Removed:**
 
-* ``ExplicitMolecule.to_json``, ``ExplicitMolecule.from_json`` removed; now uses ``GufeTokenizable`` methods
+* <news item>
 
 **Fixed:**
 


### PR DESCRIPTION
Closes #375, #458.

Also allows us to read `GufeTokenizable`s serialized previously in
`dict` representation via `.from_json`.

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
