### PR TITLE
Enforce protocol settings at instantiation

### DIFF
--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -95,6 +95,7 @@ class Protocol(GufeTokenizable):
     """
 
     _settings: Settings
+    _settings_cls: type[Settings]
     result_cls: type[ProtocolResult]
     """Corresponding `ProtocolResult` subclass."""
 
@@ -111,6 +112,15 @@ class Protocol(GufeTokenizable):
         Once the Protocol object is created, the input Settings are frozen,
         so should be finalised before creating the Protocol instance.
         """
+
+        if not hasattr(self.__class__, "_settings_cls"):
+            raise NotImplementedError(
+                f"class `{self.__class__.__qualname__}` must implement the `_settings_cls` attribute."
+            )
+
+        if not isinstance(settings, self._settings_cls):
+            raise ValueError(f"`{self.__class__.__qualname__}` expected a `{self._settings_cls.__qualname__}` instance")
+
         self._settings = settings.frozen_copy()
 
     @property

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -94,12 +94,13 @@ class Protocol(GufeTokenizable):
     - `_default_settings`
 
     Additionally, the `_settings_cls` must be set to the intended
-    subclass of `Settings`. This attribute is validated during the
-    instantiation of the Protocol.
+    subclass of `SettingsBaseModel`. This attribute is validated
+    during the instantiation of the Protocol.
+
     """
 
     _settings: Settings
-    _settings_cls: type[Settings]
+    _settings_cls: type[SettingsBaseModel]
     result_cls: type[ProtocolResult]
     """Corresponding `ProtocolResult` subclass."""
 

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -119,7 +119,9 @@ class Protocol(GufeTokenizable):
             )
 
         if not isinstance(settings, self._settings_cls):
-            raise ValueError(f"`{self.__class__.__qualname__}` expected a `{self._settings_cls.__qualname__}` instance")
+            raise ValueError(
+                f"`{self.__class__.__qualname__}` expected a `{self._settings_cls.__qualname__}` instance."
+            )
 
         self._settings = settings.frozen_copy()
 

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -92,6 +92,10 @@ class Protocol(GufeTokenizable):
     - `_create`
     - `_gather`
     - `_default_settings`
+
+    Additionally, the `_settings_cls` must be set to the intended
+    subclass of `Settings`. This attribute is validated during the
+    instantiation of the Protocol.
     """
 
     _settings: Settings

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -820,6 +820,7 @@ def test_settings_readonly():
 
 class TestEnforcedProtocolSettings:
 
+    # A boilerplate Protocol that does not define a _settings_cls
     class ProtocolMissingSettingsClass(Protocol):
 
         @classmethod
@@ -830,9 +831,11 @@ class TestEnforcedProtocolSettings:
         def _default_settings(cls):
             return settings.Settings.get_defaults()
 
+        # we don't need _create in these tests
         def _create(self):
             raise NotImplementedError
 
+        # we don't need _gather in these tests
         def _gather(self):
             raise NotImplementedError
 
@@ -846,11 +849,13 @@ class TestEnforcedProtocolSettings:
                 TestEnforcedProtocolSettings.ProtocolMissingSettingsClass.default_settings()
             )
 
-    def test_protol_no_settings(self):
+    def test_protocol_wrong_settings(self):
 
+        # Basic subclass of Settings
         class PhonySettings(settings.Settings):
             pass
 
+        # Define a protocol that expects the above Settings
         class ProtocolWithSettingsClass(TestEnforcedProtocolSettings.ProtocolMissingSettingsClass):
 
             _settings_cls = PhonySettings
@@ -859,4 +864,6 @@ class TestEnforcedProtocolSettings:
             ValueError,
             match=f"`{ProtocolWithSettingsClass.__qualname__}` expected a `{PhonySettings.__qualname__}` instance.",
         ):
-            ProtocolWithSettingsClass(TestEnforcedProtocolSettings.ProtocolMissingSettingsClass.default_settings())
+            _settings = TestEnforcedProtocolSettings.ProtocolMissingSettingsClass.default_settings()
+            # instantiate with incorrect settings object
+            ProtocolWithSettingsClass(_settings)

--- a/gufe/tests/test_protocol.py
+++ b/gufe/tests/test_protocol.py
@@ -93,6 +93,7 @@ class DummyProtocolResult(ProtocolResult):
 class DummyProtocol(Protocol):
 
     result_cls = DummyProtocolResult
+    _settings_cls = DummySpecificSettings
 
     @classmethod
     def _default_settings(cls):
@@ -542,6 +543,7 @@ class NoDepsProtocol(Protocol):
     """A protocol without dependencies"""
 
     result_cls = NoDepResults
+    _settings_cls = settings.Settings
 
     @classmethod
     def _defaults(cls):

--- a/gufe/tests/test_protocoldag.py
+++ b/gufe/tests/test_protocoldag.py
@@ -38,6 +38,7 @@ class WriterProtocolResult(gufe.ProtocolResult):
 
 class WriterProtocol(gufe.Protocol):
     result_cls = WriterProtocolResult
+    _settings_cls = WriterSettings
 
     @classmethod
     def _default_settings(cls):

--- a/news/protocol_settings_class.rst
+++ b/news/protocol_settings_class.rst
@@ -5,8 +5,9 @@
 **Changed:**
 
 * ``Protocol`` subclasses now require that the ``_settings_cls``
-  attribute is set to the intended ``Settings`` subclass. This
-  attribute is validated during ``Protocol`` instantiation.
+  attribute is set to the intended ``SettingsbaseModel``
+  subclass. This attribute is validated during ``Protocol``
+  instantiation.
 
 **Deprecated:**
 

--- a/news/protocol_settings_class.rst
+++ b/news/protocol_settings_class.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``Protocol`` subclasses now require that the ``_settings_cls``
+  attribute is set to the intended ``Settings`` subclass. This
+  attribute is validated during ``Protocol`` instantiation.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Require Protocol authors to define the _settings_cls attribute for their class. __init__ method checks that _settings_cls is define (if not raise NotImplementedError) and that the passed settings are an instance of the _settings_cls (if not raise ValueError).

Update existing Protocols in gufe to reflect this change. Closes #405.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
