### PR TITLE
Add explicit hydrogens kwarg to OpenFF export in SmallMoleculeComponent

### DIFF
--- a/gufe/components/smallmoleculecomponent.py
+++ b/gufe/components/smallmoleculecomponent.py
@@ -209,7 +209,10 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
         """
         from openff.toolkit.topology import Molecule as OFFMolecule
 
-        m = OFFMolecule(self._rdkit, allow_undefined_stereo=True)
+        m = OFFMolecule(self._rdkit,
+                        allow_undefined_stereo=True,
+                        hydrogens_are_explicit=True
+                        )
         m.name = self.name
 
         return m

--- a/gufe/components/smallmoleculecomponent.py
+++ b/gufe/components/smallmoleculecomponent.py
@@ -209,10 +209,7 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
         """
         from openff.toolkit.topology import Molecule as OFFMolecule
 
-        m = OFFMolecule.from_rdkit(self._rdkit,
-                        allow_undefined_stereo=True,
-                        hydrogens_are_explicit=True
-                        )
+        m = OFFMolecule.from_rdkit(self._rdkit, allow_undefined_stereo=True, hydrogens_are_explicit=True)
         m.name = self.name
 
         return m

--- a/gufe/components/smallmoleculecomponent.py
+++ b/gufe/components/smallmoleculecomponent.py
@@ -209,7 +209,7 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
         """
         from openff.toolkit.topology import Molecule as OFFMolecule
 
-        m = OFFMolecule(self._rdkit,
+        m = OFFMolecule.from_rdkit(self._rdkit,
                         allow_undefined_stereo=True,
                         hydrogens_are_explicit=True
                         )

--- a/news/smallmoleculecomponent-openff-hydrogens.rst
+++ b/news/smallmoleculecomponent-openff-hydrogens.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``SmallMoleculeComponent.to_openff`` now preserves protonation via ``hydrogens_are_explicit=True``
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/smallmoleculecomponent-openff-hydrogens.rst
+++ b/news/smallmoleculecomponent-openff-hydrogens.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* ``SmallMoleculeComponent.to_openff`` now preserves protonation via ``hydrogens_are_explicit=True``
+* <news item>
 
 **Deprecated:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Under some rare circumstances calling ``SmallMoleculeComponents.to_openff()`` may have lead to hydrogens being re-assigned when converted to OpenFF Molecules (e.g. during Protocol execution). ``SmallMoleculeComponents`` now explicitly pass the ``hydrogens_are_explicit=True`` flag on OpenFF Molecule creation to avoid this issue.
 
 **Security:**
 


### PR DESCRIPTION
Closes #297.

Adds `hydrogens_are_explicit=True` to `SmallMoleculeComponent.to_openff()`

Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
