### PR TITLE
switch user-set partial charges warning to log.info

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -83,7 +83,7 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
                 raise ValueError(errmsg)
 
     if np.all(np.isclose(p_chgs, 0.0)):
-        wmsg = f"Partial charges provided all equal to " "zero. These may be ignored by some Protocols."
+        wmsg = "Partial charges provided all equal to zero. These may be ignored by some Protocols."
         warnings.warn(wmsg)
     else:
         message = (

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -92,7 +92,7 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
             "partial charges."
         )
         if logger is None:
-            logger = logging.getLogger()
+            logger = logging.getLogger(__name__)
 
         logger.info(message)
 

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -86,7 +86,7 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
         wmsg = f"Partial charges provided all equal to " "zero. These may be ignored by some Protocols."
         warnings.warn(wmsg)
     else:
-        wmsg = (
+        message = (
             "Partial charges have been provided, these will "
             "preferentially be used instead of generating new "
             "partial charges."
@@ -94,7 +94,7 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
         if logger is None:
             logger = logging.getLogger()
 
-        logger.info(wmsg)
+        logger.info(message)
 
 
 class ExplicitMoleculeComponent(Component):

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import warnings
 from typing import Optional
 
@@ -34,7 +35,7 @@ def _ensure_ofe_name(mol: RDKitMol, name: str) -> str:
     return name
 
 
-def _check_partial_charges(mol: RDKitMol) -> None:
+def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
     """
     Checks for the presence of partial charges.
 
@@ -88,9 +89,12 @@ def _check_partial_charges(mol: RDKitMol) -> None:
         wmsg = (
             "Partial charges have been provided, these will "
             "preferentially be used instead of generating new "
-            "partial charges"
+            "partial charges."
         )
-        warnings.warn(wmsg)
+        if logger is None:
+            logger = logging.getLogger()
+
+        logger.info(wmsg)
 
 
 class ExplicitMoleculeComponent(Component):
@@ -106,7 +110,7 @@ class ExplicitMoleculeComponent(Component):
 
     def __init__(self, rdkit: RDKitMol, name: str = ""):
         name = _ensure_ofe_name(rdkit, name)
-        _check_partial_charges(rdkit)
+        _check_partial_charges(rdkit, logger=self.logger)
         conformers = list(rdkit.GetConformers())
         if not conformers:
             raise ValueError("Molecule was provided with no conformers.")

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -87,9 +87,9 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
         warnings.warn(wmsg)
     else:
         msg = "Partial charges have been provided"
-        if name:= mol.GetProp("ofe-name"):
-            msg+= f" for {name}"
-        msg+=", these will preferentially be used instead of generating new partial charges."
+        if name := mol.GetProp("ofe-name"):
+            msg += f" for {name}"
+        msg += ", these will preferentially be used instead of generating new partial charges."
 
         if logger is None:
             logger = logging.getLogger(__name__)

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -86,15 +86,15 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
         wmsg = "Partial charges provided all equal to zero. These may be ignored by some Protocols."
         warnings.warn(wmsg)
     else:
-        message = (
-            "Partial charges have been provided, these will "
-            "preferentially be used instead of generating new "
-            "partial charges."
-        )
+        msg = "Partial charges have been provided"
+        if name:= mol.GetProp("ofe-name"):
+            msg+= f" for {name}"
+        msg+=", these will preferentially be used instead of generating new partial charges."
+
         if logger is None:
             logger = logging.getLogger(__name__)
 
-        logger.info(message)
+        logger.info(msg)
 
 
 class ExplicitMoleculeComponent(Component):

--- a/gufe/tests/test_explicitmoleculecomponent.py
+++ b/gufe/tests/test_explicitmoleculecomponent.py
@@ -1,5 +1,6 @@
 import pickle
 
+
 class ExplicitMoleculeComponentMixin:
 
     def test_pickle(self, instance):

--- a/gufe/tests/test_explicitmoleculecomponent.py
+++ b/gufe/tests/test_explicitmoleculecomponent.py
@@ -1,6 +1,5 @@
 import pickle
 
-
 class ExplicitMoleculeComponentMixin:
 
     def test_pickle(self, instance):

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -243,8 +243,8 @@ class TestSmallMoleculeComponentConversion:
 @pytest.mark.skipif(not HAS_OFFTK, reason="no openff tookit available")
 class TestSmallMoleculeComponentPartialCharges:
     @pytest.fixture(scope="function")
-    def charged_off_ethane(self, ethane):
-        off_ethane = ethane.to_openff()
+    def charged_off_ethane(self, named_ethane):
+        off_ethane = named_ethane.to_openff()
         off_ethane.assign_partial_charges(partial_charge_method="am1bcc")
         return off_ethane
 
@@ -252,7 +252,7 @@ class TestSmallMoleculeComponentPartialCharges:
         rd_mol = charged_off_ethane.to_rdkit()
         caplog.set_level(logging.INFO)
         _check_partial_charges(rd_mol, logger=None)
-        assert "Partial charges have been provided" in caplog.text
+        assert "Partial charges have been provided for ethane, these" in caplog.text
 
     def test_partial_charges_logging(self, charged_off_ethane, caplog):
         caplog.set_level(logging.INFO)

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -22,7 +22,7 @@ from rdkit.Chem import AllChem
 
 import gufe
 from gufe import SmallMoleculeComponent
-from gufe.components.explicitmoleculecomponent import _ensure_ofe_name
+from gufe.components.explicitmoleculecomponent import _ensure_ofe_name, _check_partial_charges
 from gufe.tokenization import TOKENIZABLE_REGISTRY
 
 from .test_explicitmoleculecomponent import ExplicitMoleculeComponentMixin
@@ -74,7 +74,6 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 
     assert out_name == expected
     assert rdkit.GetProp("ofe-name") == out_name
-
 
 class TestSmallMoleculeComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComponentMixin):
 
@@ -247,6 +246,13 @@ class TestSmallMoleculeComponentPartialCharges:
         off_ethane = ethane.to_openff()
         off_ethane.assign_partial_charges(partial_charge_method="am1bcc")
         return off_ethane
+
+    def test_check_partial_charges_without_gufe_logger(self, charged_off_ethane, caplog):
+        rd_mol = charged_off_ethane.to_rdkit()
+        caplog.set_level(logging.INFO)
+        _check_partial_charges(rd_mol, logger=None)
+        assert "Partial charges have been provided" in caplog.text
+
 
     def test_partial_charges_logging(self, charged_off_ethane, caplog):
         caplog.set_level(logging.INFO)

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -14,6 +14,7 @@ else:
 import json
 import os
 from unittest import mock
+import logging
 
 import pytest
 from rdkit import Chem
@@ -247,10 +248,11 @@ class TestSmallMoleculeComponentPartialCharges:
         off_ethane.assign_partial_charges(partial_charge_method="am1bcc")
         return off_ethane
 
-    def test_partial_charges_warning(self, charged_off_ethane):
-        matchmsg = "Partial charges have been provided"
-        with pytest.warns(UserWarning, match=matchmsg):
-            SmallMoleculeComponent.from_openff(charged_off_ethane)
+    def test_partial_charges_logging(self, charged_off_ethane, caplog):
+        caplog.set_level(logging.INFO)
+        SmallMoleculeComponent.from_openff(charged_off_ethane)
+
+        assert "Partial charges have been provided" in caplog.text
 
     def test_partial_charges_zero_warning(self, charged_off_ethane):
         charged_off_ethane.partial_charges[:] = 0 * unit.elementary_charge
@@ -271,7 +273,7 @@ class TestSmallMoleculeComponentPartialCharges:
         with pytest.raises(ValueError, match="Incorrect number of"):
             SmallMoleculeComponent.from_rdkit(mol)
 
-    def test_partial_charges_applied_to_atoms(self):
+    def test_partial_charges_applied_to_atoms(self, caplog):
         """
         Make sure that charges set at the molecule level
         are transferred to atoms and picked up by openFF.
@@ -280,9 +282,11 @@ class TestSmallMoleculeComponentPartialCharges:
         Chem.AllChem.Compute2DCoords(mol)
         # add some fake charges at the molecule level
         mol.SetProp("atom.dprop.PartialCharge", "-1 0.25 0.25 0.25 0.25")
-        matchmsg = "Partial charges have been provided"
-        with pytest.warns(UserWarning, match=matchmsg):
-            ofe = SmallMoleculeComponent.from_rdkit(mol)
+        caplog.set_level(logging.INFO)
+
+        ofe = SmallMoleculeComponent.from_rdkit(mol)
+        assert "Partial charges have been provided" in caplog.text
+
         # convert to openff and make sure the charges are set
         off_mol = ofe.to_openff()
         assert off_mol.partial_charges is not None

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -12,9 +12,9 @@ except ImportError:
 else:
     HAS_OFFTK = True
 import json
+import logging
 import os
 from unittest import mock
-import logging
 
 import pytest
 from rdkit import Chem
@@ -22,7 +22,7 @@ from rdkit.Chem import AllChem
 
 import gufe
 from gufe import SmallMoleculeComponent
-from gufe.components.explicitmoleculecomponent import _ensure_ofe_name, _check_partial_charges
+from gufe.components.explicitmoleculecomponent import _check_partial_charges, _ensure_ofe_name
 from gufe.tokenization import TOKENIZABLE_REGISTRY
 
 from .test_explicitmoleculecomponent import ExplicitMoleculeComponentMixin
@@ -74,6 +74,7 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 
     assert out_name == expected
     assert rdkit.GetProp("ofe-name") == out_name
+
 
 class TestSmallMoleculeComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComponentMixin):
 
@@ -252,7 +253,6 @@ class TestSmallMoleculeComponentPartialCharges:
         caplog.set_level(logging.INFO)
         _check_partial_charges(rd_mol, logger=None)
         assert "Partial charges have been provided" in caplog.text
-
 
     def test_partial_charges_logging(self, charged_off_ethane, caplog):
         caplog.set_level(logging.INFO)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Addresses #330 

We decided to use `logger.info`, since it is encouraged for users to pre-set partial charges, and we shouldn't be yelling at them for that.

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
