### PR TITLE
Add zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![coverage](https://codecov.io/gh/OpenFreeEnergy/gufe/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenFreeEnergy/gufe)
 [![Documentation Status](https://readthedocs.org/projects/gufe/badge/?version=latest)](https://gufe.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/OpenFreeEnergy/gufe/main.svg)](https://results.pre-commit.ci/latest/github/OpenFreeEnergy/gufe/main)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14624350.svg)](https://doi.org/10.5281/zenodo.14624350)
 
 # gufe - Grand Unified Free Energy
 


### PR DESCRIPTION
Simple PR, just adding the zenodo badge.

WIll self-merge this one due to the innocuous change being added.

We should follow this up with a citation CFF file (see #457 )

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
