### PR TITLE
partial charge checking - throw error for negative net charge diff

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -63,7 +63,8 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
         errmsg = f"Incorrect number of partial charges: {len(p_chgs)} " f" were provided for {mol.GetNumAtoms()} atoms"
         raise ValueError(errmsg)
 
-    if (sum(p_chgs) - Chem.GetFormalCharge(mol)) > 0.01:
+    if abs(sum(p_chgs) - Chem.GetFormalCharge(mol)) > 0.01:
+        import pdb;pdb.set_trace()
         errmsg = (
             f"Sum of partial charges {sum(p_chgs)} differs from " f"RDKit formal charge {Chem.GetFormalCharge(mol)}"
         )

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -64,7 +64,6 @@ def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
         raise ValueError(errmsg)
 
     if abs(sum(p_chgs) - Chem.GetFormalCharge(mol)) > 0.01:
-        import pdb;pdb.set_trace()
         errmsg = (
             f"Sum of partial charges {sum(p_chgs)} differs from " f"RDKit formal charge {Chem.GetFormalCharge(mol)}"
         )

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -266,8 +266,9 @@ class TestSmallMoleculeComponentPartialCharges:
         with pytest.warns(UserWarning, match=matchmsg):
             SmallMoleculeComponent.from_openff(charged_off_ethane)
 
-    def test_partial_charges_not_formal_error(self, charged_off_ethane):
-        charged_off_ethane.partial_charges[:] = 1 * unit.elementary_charge
+    @pytest.mark.parametrize("wrong_charge_val", [-1, 1])
+    def test_partial_charges_not_formal_error(self, charged_off_ethane, wrong_charge_val):
+        charged_off_ethane.partial_charges[:] = wrong_charge_val * unit.elementary_charge
         with pytest.raises(ValueError, match="Sum of partial charges"):
             SmallMoleculeComponent.from_openff(charged_off_ethane)
 

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -238,7 +238,6 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         patch_loc = "gufe.tokenization.TOKENIZABLE_REGISTRY"
         registry = dict(TOKENIZABLE_REGISTRY)
         with mock.patch.dict(patch_loc, registry, clear=True):
-            # import pdb; pdb.set_trace()
             leaf._set_key("qux")
             assert leaf.key == "qux"
             assert TOKENIZABLE_REGISTRY["qux"] is leaf

--- a/news/partial_charge_sum_fix.rst
+++ b/news/partial_charge_sum_fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed bug where an error was only being raised if the difference between the sum of partial charges and the small molecule's net charge was a positive value. Behavior has been fixed such that negative discrepancies now raise an error as well.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Currently, if the net charge on a molecule is negative, the `Sum of partial charges differs` error does not get raised. I updated the check so that it's evaluating the absolute value of the difference between expected and calculated net charge.

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
