### PR TITLE
Update partial charge check

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -68,7 +68,6 @@ class ExplicitMoleculeComponent(Component):
 
         self._check_partial_charges()
 
-
     def __getstate__(self):
         # TODO: check that RDKit setting is set before issuing warning
         if Chem.GetDefaultPickleProperties() != Chem.PropertyPickleOptions.AllProps:
@@ -154,7 +153,9 @@ class ExplicitMoleculeComponent(Component):
         p_chgs = np.array(mol.GetProp("atom.dprop.PartialCharge").split(), dtype=float)
 
         if len(p_chgs) != mol.GetNumAtoms():
-            errmsg = f"Incorrect number of partial charges: {len(p_chgs)} " f" were provided for {mol.GetNumAtoms()} atoms"
+            errmsg = (
+                f"Incorrect number of partial charges: {len(p_chgs)} " f" were provided for {mol.GetNumAtoms()} atoms"
+            )
             raise ValueError(errmsg)
 
         if abs(sum(p_chgs) - Chem.GetFormalCharge(mol)) > 0.01:
@@ -172,7 +173,8 @@ class ExplicitMoleculeComponent(Component):
                 atom_charge = atom.GetDoubleProp("PartialCharge")
                 if not np.isclose(atom_charge, charge):
                     errmsg = (
-                        f"non-equivalent partial charges between atom and " f"molecule properties: {atom_charge} {charge}"
+                        f"non-equivalent partial charges between atom and "
+                        f"molecule properties: {atom_charge} {charge}"
                     )
                     raise ValueError(errmsg)
 

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -180,5 +180,5 @@ class ExplicitMoleculeComponent(Component):
             wmsg = "Partial charges provided all equal to zero. These may be ignored by some Protocols."
             warnings.warn(wmsg)
         else:
-            msg = f"Partial charges are present for {self.key} (name: {self.name})"
+            msg = f"Partial charges are present for {self.key} (name: '{self.name}')"
             self.logger.info(msg)

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -35,68 +35,6 @@ def _ensure_ofe_name(mol: RDKitMol, name: str) -> str:
     return name
 
 
-def _check_partial_charges(mol: RDKitMol, logger=None) -> None:
-    """
-    Checks for the presence of partial charges.
-
-    Note
-    ----
-    We ensure the charges are set as atom properties
-    to ensure they are detected by OpenFF
-
-    Raises
-    ------
-    ValueError
-      * If the partial charges are not of length atoms.
-      * If the sum of partial charges is not equal to the
-        formal charge.
-    UserWarning
-      * If partial charges are found.
-      * If the partial charges are near 0 for all atoms.
-    """
-    if "atom.dprop.PartialCharge" not in mol.GetPropNames():
-        return
-
-    p_chgs = np.array(mol.GetProp("atom.dprop.PartialCharge").split(), dtype=float)
-
-    if len(p_chgs) != mol.GetNumAtoms():
-        errmsg = f"Incorrect number of partial charges: {len(p_chgs)} " f" were provided for {mol.GetNumAtoms()} atoms"
-        raise ValueError(errmsg)
-
-    if abs(sum(p_chgs) - Chem.GetFormalCharge(mol)) > 0.01:
-        errmsg = (
-            f"Sum of partial charges {sum(p_chgs)} differs from " f"RDKit formal charge {Chem.GetFormalCharge(mol)}"
-        )
-        raise ValueError(errmsg)
-
-    # set the charges on the atoms if not already set
-    for i, charge in enumerate(p_chgs):
-        atom = mol.GetAtomWithIdx(i)
-        if not atom.HasProp("PartialCharge"):
-            atom.SetDoubleProp("PartialCharge", charge)
-        else:
-            atom_charge = atom.GetDoubleProp("PartialCharge")
-            if not np.isclose(atom_charge, charge):
-                errmsg = (
-                    f"non-equivalent partial charges between atom and " f"molecule properties: {atom_charge} {charge}"
-                )
-                raise ValueError(errmsg)
-
-    if np.all(np.isclose(p_chgs, 0.0)):
-        wmsg = "Partial charges provided all equal to zero. These may be ignored by some Protocols."
-        warnings.warn(wmsg)
-    else:
-        msg = "Partial charges have been provided"
-        if name := mol.GetProp("ofe-name"):
-            msg += f" for {name}"
-        msg += ", these will preferentially be used instead of generating new partial charges."
-
-        if logger is None:
-            logger = logging.getLogger(__name__)
-
-        logger.info(msg)
-
-
 class ExplicitMoleculeComponent(Component):
     """Base class for explicit molecules.
 
@@ -110,7 +48,6 @@ class ExplicitMoleculeComponent(Component):
 
     def __init__(self, rdkit: RDKitMol, name: str = ""):
         name = _ensure_ofe_name(rdkit, name)
-        _check_partial_charges(rdkit, logger=self.logger)
         conformers = list(rdkit.GetConformers())
         if not conformers:
             raise ValueError("Molecule was provided with no conformers.")
@@ -128,6 +65,9 @@ class ExplicitMoleculeComponent(Component):
         self._rdkit = rdkit
         self._smiles: Optional[str] = None
         self._name = name
+
+        self._check_partial_charges()
+
 
     def __getstate__(self):
         # TODO: check that RDKit setting is set before issuing warning
@@ -186,3 +126,59 @@ class ExplicitMoleculeComponent(Component):
 
     def _to_dict(self) -> dict:
         raise NotImplementedError()
+
+    def _check_partial_charges(self) -> None:
+        """
+        Checks for the presence of partial charges.
+
+        Note
+        ----
+        We ensure the charges are set as atom properties
+        to ensure they are detected by OpenFF
+
+        Raises
+        ------
+        ValueError
+        * If the partial charges are not of length atoms.
+        * If the sum of partial charges is not equal to the
+            formal charge.
+        UserWarning
+        * If partial charges are found.
+        * If the partial charges are near 0 for all atoms.
+        """
+        mol = self._rdkit
+
+        if "atom.dprop.PartialCharge" not in mol.GetPropNames():
+            return
+
+        p_chgs = np.array(mol.GetProp("atom.dprop.PartialCharge").split(), dtype=float)
+
+        if len(p_chgs) != mol.GetNumAtoms():
+            errmsg = f"Incorrect number of partial charges: {len(p_chgs)} " f" were provided for {mol.GetNumAtoms()} atoms"
+            raise ValueError(errmsg)
+
+        if abs(sum(p_chgs) - Chem.GetFormalCharge(mol)) > 0.01:
+            errmsg = (
+                f"Sum of partial charges {sum(p_chgs)} differs from " f"RDKit formal charge {Chem.GetFormalCharge(mol)}"
+            )
+            raise ValueError(errmsg)
+
+        # set the charges on the atoms if not already set
+        for i, charge in enumerate(p_chgs):
+            atom = mol.GetAtomWithIdx(i)
+            if not atom.HasProp("PartialCharge"):
+                atom.SetDoubleProp("PartialCharge", charge)
+            else:
+                atom_charge = atom.GetDoubleProp("PartialCharge")
+                if not np.isclose(atom_charge, charge):
+                    errmsg = (
+                        f"non-equivalent partial charges between atom and " f"molecule properties: {atom_charge} {charge}"
+                    )
+                    raise ValueError(errmsg)
+
+        if np.all(np.isclose(p_chgs, 0.0)):
+            wmsg = "Partial charges provided all equal to zero. These may be ignored by some Protocols."
+            warnings.warn(wmsg)
+        else:
+            msg = f"Partial charges are present for {self.key} (name: {self.name})"
+            self.logger.info(msg)

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -22,7 +22,7 @@ from rdkit.Chem import AllChem
 
 import gufe
 from gufe import SmallMoleculeComponent
-from gufe.components.explicitmoleculecomponent import _check_partial_charges, _ensure_ofe_name
+from gufe.components.explicitmoleculecomponent import _ensure_ofe_name
 from gufe.tokenization import TOKENIZABLE_REGISTRY
 
 from .test_explicitmoleculecomponent import ExplicitMoleculeComponentMixin
@@ -247,12 +247,6 @@ class TestSmallMoleculeComponentPartialCharges:
         off_ethane = named_ethane.to_openff()
         off_ethane.assign_partial_charges(partial_charge_method="am1bcc")
         return off_ethane
-
-    def test_check_partial_charges_without_gufe_logger(self, charged_off_ethane, caplog):
-        rd_mol = charged_off_ethane.to_rdkit()
-        caplog.set_level(logging.INFO)
-        _check_partial_charges(rd_mol, logger=None)
-        assert "Partial charges have been provided for ethane, these" in caplog.text
 
     def test_partial_charges_logging(self, charged_off_ethane, caplog):
         caplog.set_level(logging.INFO)

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -252,7 +252,7 @@ class TestSmallMoleculeComponentPartialCharges:
         caplog.set_level(logging.INFO)
         SmallMoleculeComponent.from_openff(charged_off_ethane)
 
-        assert "Partial charges have been provided" in caplog.text
+        assert "Partial charges are present for SmallMoleculeComponent-" in caplog.text
 
     def test_partial_charges_zero_warning(self, charged_off_ethane):
         charged_off_ethane.partial_charges[:] = 0 * unit.elementary_charge
@@ -286,7 +286,7 @@ class TestSmallMoleculeComponentPartialCharges:
         caplog.set_level(logging.INFO)
 
         ofe = SmallMoleculeComponent.from_rdkit(mol)
-        assert "Partial charges have been provided" in caplog.text
+        assert "Partial charges are present for SmallMoleculeComponent-" in caplog.text
 
         # convert to openff and make sure the charges are set
         off_mol = ofe.to_openff()

--- a/news/partial_charge_warning_to_logger.rst
+++ b/news/partial_charge_warning_to_logger.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The message stating that partial charges are already present in an ``ExplicitMoleculeComponent`` is now included in ``logger.info``, rather than as a warning message. This should make output significantly less noisy for some users.   
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Based off conversation with @dotsdl and @jthorton, we decided to update this logging message to include more molecular identifying information.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [ x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
