### PR TITLE
Add name sanitization 

### DIFF
--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -14,7 +14,8 @@ from .component import Component
 def _ensure_ofe_name(mol: RDKitMol, name: str) -> str:
     """
     Determine the correct name from the rdkit.Chem.Mol and the user-provided
-    name; ensure that is set in the rdkit representation.
+    name; ensure that is set in the rdkit representation. We also perform some sanitation of the name
+    to help downstream tools.
     """
     try:
         rdkit_name = mol.GetProp("_Name")
@@ -30,6 +31,16 @@ def _ensure_ofe_name(mol: RDKitMol, name: str) -> str:
         warnings.warn(f"Component being renamed from {rdkit_name}" f"to {name}.")
     elif name == "":
         name = rdkit_name
+
+    # sanitize the name before we set it
+    # list of characters to replace
+    to_replace = [" ", "/"]
+    if any([i in name for i in to_replace]):
+        # strip leading and trailing whitespace
+        name = name.strip()
+        for i in to_replace:
+            name = name.replace(i, "-")
+        warnings.warn(f"Component name sanitized to: {name}")
 
     mol.SetProp("ofe-name", name)
     return name

--- a/gufe/components/explicitmoleculecomponent.py
+++ b/gufe/components/explicitmoleculecomponent.py
@@ -34,12 +34,12 @@ def _ensure_ofe_name(mol: RDKitMol, name: str) -> str:
 
     # sanitize the name before we set it
     # list of characters to replace
-    to_replace = [" ", "/"]
+    to_replace = [" ", "/", "*"]
     if any([i in name for i in to_replace]):
         # strip leading and trailing whitespace
         name = name.strip()
         for i in to_replace:
-            name = name.replace(i, "-")
+            name = name.replace(i, "")
         warnings.warn(f"Component name sanitized to: {name}")
 
     mol.SetProp("ofe-name", name)

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -52,6 +52,10 @@ def named_ethane():
         ("bar", "", "foo", "foo"),
         ("baz", "bar", "foo", "foo"),
         ("foo", "", "", "foo"),
+        ("foo/bar", "", "", "foo-bar"),
+        (" foo bar ", "", "", "foo-bar"),
+        ("foo", "foo/bar", "", "foo-bar"),
+        ("", "", "foo/bar", "foo-bar")
     ],
 )
 def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
@@ -64,7 +68,12 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 
     out_name = _ensure_ofe_name(rdkit, name)
 
-    if {rdkit_name, internal} - {"foo", ""}:
+    if "-" in expected:
+        # we should warn if we have sanitized the name
+        assert len(recwarn) == 1
+        assert f"Component name sanitized to: {expected}" in recwarn[0].message.args[0]
+
+    elif {rdkit_name, internal} - {"foo", ""}:
         # we should warn if rdkit properties are anything other than 'foo'
         # (expected) or the empty string (not set)
         assert len(recwarn) == 1

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -52,10 +52,11 @@ def named_ethane():
         ("bar", "", "foo", "foo"),
         ("baz", "bar", "foo", "foo"),
         ("foo", "", "", "foo"),
-        ("foo/bar", "", "", "foo-bar"),
-        (" foo bar ", "", "", "foo-bar"),
-        ("foo", "foo/bar", "", "foo-bar"),
-        ("", "", "foo/bar", "foo-bar")
+        ("foo/bar", "", "", "foobar"),
+        (" foo bar ", "", "", "foobar"),
+        ("foo*bar", "", "", "foobar"),
+        ("foo", "foo/bar", "", "foobar"),
+        ("", "", "foo/bar", "foobar")
     ],
 )
 def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
@@ -68,7 +69,7 @@ def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):
 
     out_name = _ensure_ofe_name(rdkit, name)
 
-    if "-" in expected:
+    if "bar" in expected:
         # we should warn if we have sanitized the name
         assert len(recwarn) == 1
         assert f"Component name sanitized to: {expected}" in recwarn[0].message.args[0]

--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -56,7 +56,7 @@ def named_ethane():
         (" foo bar ", "", "", "foobar"),
         ("foo*bar", "", "", "foobar"),
         ("foo", "foo/bar", "", "foobar"),
-        ("", "", "foo/bar", "foobar")
+        ("", "", "foo/bar", "foobar"),
     ],
 )
 def test_ensure_ofe_name(internal, rdkit_name, name, expected, recwarn):

--- a/news/ligand_name_cleanup.rst
+++ b/news/ligand_name_cleanup.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The name of an ``ExplicitMoleculeComponent`` and its subclasses will now be sanitized to remove whitespace, ``/`` and ``*`` characters, a warning will be displayed when this happens.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Fixes #474 by adding some basic name sanitization. 

## Questions 
- Are there any other name characters we should lookout for?
- Are we happy having a warning every time we rename something or should be a logging info message as its only our internal name that we change? 
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
