### PR TITLE
Use correct default shell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,6 @@ jobs:
       - name: "install checks"
         working-directory: ./dist
         run: |
-          pip check
           python -Ic "import gufe; print(gufe.__version__)"
 
       - name: "run tests"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -leo pipefail {0}
 
 jobs:
   tests:

--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -leo pipefail {0}
 
 jobs:
   condacheck:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -30,7 +30,6 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=3.10
-            rdkit=2023.09.5
           init-shell: bash
 
       - name: "Install steps"

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -leo pipefail {0}
 
 jobs:
   mypy:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -30,6 +30,7 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=3.10
+            rdkit=2023.09.5
           init-shell: bash
 
       - name: "Install steps"

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Environment Information"
         run: |
-          micromamba info -a
+          micromamba info
           micromamba list
 
       - name: "Lint with mypy"

--- a/news/partial_charge_warning_to_logger.rst
+++ b/news/partial_charge_warning_to_logger.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* The message stating that partial charges are already present in an ``ExplicitMoleculeComponent`` is now included in ``logger.info``, rather than as a warning message. This should make output significantly less noisy for some users.   
+* The message stating that partial charges are already present in an ``ExplicitMoleculeComponent`` is now included in ``logger.info``, rather than as a warning message. This should make output significantly less noisy for some users.
 
 **Deprecated:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


This makes sure we use a default shell that will throw errors has they happen. This also drops the rdkit pin in the mypy tests since that has been fixed upstream.