### PR TITLE
[WIP] Implement msgpack serialization/deserialization

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - pip
   - pydantic >1
   - zstandard
+  - msgpack-python
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/gufe/custom_msgpack.py
+++ b/gufe/custom_msgpack.py
@@ -1,0 +1,27 @@
+from enum import Enum
+
+import msgpack
+import numpy as np
+
+from gufe.tokenization import GufeTokenizable
+
+class MPEXT(Enum):
+    GUFETOKENIZABLE
+    TIMESTAMP
+    INT128
+    SETTINGS
+    UNIT
+    NDARRAY
+    PATH
+
+def pack_default():
+    raise NotImplementedError
+
+def unpack_default():
+    raise NotImplementedError
+
+def packb(obj) -> bytes:
+    return msgpack.packb(obj, default=default)
+
+def unpackb(data: bytes):
+    raise NotImplementedError

--- a/gufe/custom_msgpack.py
+++ b/gufe/custom_msgpack.py
@@ -1,27 +1,125 @@
-from enum import Enum
+import uuid
+from datetime import datetime
+from enum import IntEnum
+from pathlib import Path
 
 import msgpack
 import numpy as np
+import pint
+from openff.units import DEFAULT_UNIT_REGISTRY
 
+import gufe
+from gufe.settings import SettingsBaseModel
 from gufe.tokenization import GufeTokenizable
 
-class MPEXT(Enum):
-    GUFETOKENIZABLE
-    TIMESTAMP
-    INT128
-    SETTINGS
-    UNIT
-    NDARRAY
-    PATH
 
-def pack_default():
-    raise NotImplementedError
+class MPEXT(IntEnum):
+    TIMESTAMP = 0
+    INT128 = 1
+    PATH = 2
+    UNIT = 3
+    NDARRAY = 4
+    NPGENERIC = 5
+    GUFETOKENIZABLE = 6
+    SETTINGS = 7
+    UUID = 8
 
-def unpack_default():
-    raise NotImplementedError
+
+def pack_int128(large_int: int) -> bytes:
+    return msgpack.packb(str(large_int))
+
+
+def pack_default(obj) -> msgpack.ExtType:
+    """For non-standard datatypes, create an ExtType containing packed
+    data."""
+    match obj:
+        case GufeTokenizable():
+            data = obj.to_keyed_chain()
+            return msgpack.ExtType(MPEXT.GUFETOKENIZABLE.value, msgpack.packb(data, default=pack_default))
+        case datetime():
+            data = msgpack.ext.Timestamp.from_datetime(obj)
+            return msgpack.ExtType(MPEXT.TIMESTAMP.value, data.to_bytes())
+        case SettingsBaseModel():
+            data = {field: getattr(obj, field) for field in obj.__fields__}
+            data.update({"__class__": obj.__class__.__qualname__, "__module__": obj.__class__.__module__})
+            return msgpack.ExtType(MPEXT.SETTINGS.value, msgpack.packb(data, default=pack_default))
+        case pint.Quantity():
+
+            return msgpack.ExtType(
+                MPEXT.UNIT.value,
+                msgpack.packb(
+                    {
+                        "magnitude": obj.m,
+                        "unit": str(obj.u),
+                        "pint_unit_registry": "openff_units",
+                    },
+                    default=pack_default,
+                ),
+            )
+        case Path():
+            return msgpack.ExtType(MPEXT.PATH.value, msgpack.packb(str(obj)))
+        case np.generic():
+            data = [str(obj.dtype), obj.tobytes()]
+            return msgpack.ExtType(MPEXT.NPGENERIC.value, msgpack.packb(data, default=pack_default))
+        case np.ndarray():
+            # data = {"dtype": str(obj.dtype), "shape": list(obj.shape), "bytes": obj.tobytes()}
+            data = [str(obj.dtype), list(obj.shape), obj.tobytes()]
+            return msgpack.ExtType(MPEXT.NDARRAY.value, msgpack.packb(data))
+        case int():
+            try:
+                return msgpack.packb(obj)
+            except OverflowError:
+                return msgpack.ExtType(MPEXT.INT128.value, pack_int128(obj))
+        case uuid.UUID():
+            # since a UUID is really a 128 bit int, rely on the INT128 extension type downstream
+            data = msgpack.packb(int(obj), default=pack_default)
+            return msgpack.ExtType(MPEXT.UUID.value, data)
+
+
+def unpack_default(code: int, data: bytes):
+    """For non-standard datatypes, unpack into the appropriate structures."""
+    match MPEXT(code):
+        case MPEXT.GUFETOKENIZABLE:
+            return gufe.tokenization.KeyedChain(
+                msgpack.unpackb(data, ext_hook=unpack_default, strict_map_key=False)
+            ).to_gufe()
+        case MPEXT.SETTINGS:
+            data = msgpack.unpackb(data, ext_hook=unpack_default)
+            try:
+                module = data.pop("__module__")
+                qualname = data.pop("__class__")
+            except KeyError as e:
+                raise e
+            cls = gufe.tokenization.get_class(module, qualname)
+            return cls(**data)
+        case MPEXT.UNIT:
+            data = msgpack.unpackb(data, ext_hook=unpack_default)
+            unit_data = data["magnitude"] * DEFAULT_UNIT_REGISTRY.Quantity(data["unit"])
+            return data["magnitude"] * DEFAULT_UNIT_REGISTRY.Quantity(data["unit"])
+        case MPEXT.NDARRAY:
+            _dtype, _shape, _bytes = msgpack.unpackb(data)
+            return np.frombuffer(_bytes, dtype=np.dtype(_dtype)).reshape(_shape)
+        case MPEXT.INT128:
+            string_rep_data = msgpack.unpackb(data)
+            return int(string_rep_data)
+        case MPEXT.PATH:
+            string_rep_data = msgpack.unpackb(data)
+            return Path(string_rep_data)
+        case MPEXT.TIMESTAMP:
+            return msgpack.ext.Timestamp.from_bytes(data).to_datetime()
+        case MPEXT.UUID:
+            data = msgpack.unpackb(data, ext_hook=unpack_default)
+            return uuid.UUID(int=int(data))
+        case MPEXT.NPGENERIC:
+            _dtype, _bytes = msgpack.unpackb(data, ext_hook=unpack_default)
+            return np.frombuffer(_bytes, dtype=np.dtype(_dtype))
+        case _:
+            raise NotImplementedError(code)
+
 
 def packb(obj) -> bytes:
-    return msgpack.packb(obj, default=default)
+    return msgpack.packb(obj, default=pack_default)
+
 
 def unpackb(data: bytes):
-    raise NotImplementedError
+    return msgpack.unpackb(data, ext_hook=unpack_default)

--- a/gufe/protocols/protocol.py
+++ b/gufe/protocols/protocol.py
@@ -1,9 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
-"""Classes in this module must be subclassed by protocol authors.
-
-"""
+"""Classes in this module must be subclassed by protocol authors."""
 
 import abc
 import warnings

--- a/gufe/tests/test_custom_msgpack.py
+++ b/gufe/tests/test_custom_msgpack.py
@@ -1,0 +1,125 @@
+import abc
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import openff
+import pytest
+from numpy import testing as npt
+
+from gufe.custom_msgpack import packb, unpackb
+from gufe.settings import models
+
+
+class CustomMessagePackCodingTest(abc.ABC):
+
+    @abc.abstractmethod
+    def setup_method(self):
+        return NotImplementedError
+
+    def _equality_check(self, original, reconstructed):
+        assert original == reconstructed
+
+    def test_round_trip(self):
+        for obj in self.objs:
+            msgpack_bytes = packb(obj)
+            reconstructed = unpackb(msgpack_bytes)
+
+            self._equality_check(obj, reconstructed)
+
+
+class TestNumpyCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        self.objs = [
+            np.array([[1.0, 0.0], [2.0, 3.2]]),
+            np.array([1, 0]),
+            np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            np.array([1.0, 2.0, 3.0], dtype=np.float16),
+        ]
+
+    def _equality_check(self, original, reconstructed):
+        npt.assert_array_equal(original, reconstructed)
+        assert original.dtype == reconstructed.dtype
+
+
+# TODO this is technically anything greater than 64 bit
+class TestInt128Coding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        self.objs = [
+            -1,
+            0,
+            1,
+            2 ^ 64,
+            2 ^ 128,
+            2 ^ 256,
+        ]
+
+
+class TestPathCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        self.objs = [
+            Path("/"),
+            Path("/foo"),
+            Path("/foo/bar"),
+            Path("."),
+            Path("./foo/"),
+        ]
+
+
+class TestNumpyGenericCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        self.objs = [
+            np.bool_(True),
+            np.float16(1.0),
+            np.float32(1.0),
+            np.complex128(1.0),
+            np.clongdouble(1.0),
+            np.uint64(1),
+        ]
+
+
+class TestUnitCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        # TODO this is not exhaustive
+        self.objs = [
+            openff.units.DEFAULT_UNIT_REGISTRY("1.0 * kg meter per second squared"),
+        ]
+
+
+class TestSettingsCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        self.objs = [
+            models.Settings.get_defaults(),
+        ]
+
+
+class TestGufeTokenizableCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self, network):
+        # due to restrictions from pytest, just skip the setup_method
+        pass
+
+    def test_round_trip(self, benzene_variants_star_map):
+        msgpack_bytes = packb(benzene_variants_star_map)
+        reconstructed = unpackb(msgpack_bytes)
+
+        self._equality_check(benzene_variants_star_map, reconstructed)
+
+
+class TestTimeStampCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        self.objs = [datetime.now(timezone.utc)]
+
+
+class TestUUIDCoding(CustomMessagePackCodingTest):
+
+    def setup_method(self):
+        self.objs = [uuid.uuid4() for _ in range(3)]

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -715,6 +715,42 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
 
         return cls.from_keyed_chain(keyed_chain=keyed_chain)
 
+    def to_msgpack(self, file: Optional[PathLike | TextIO] = None) -> None | bytes:
+        # TODO: docstring
+
+        # need to import here to avoid circular imports
+        from gufe.custom_msgpack import packb
+
+        if file is not None:
+            from gufe.utils import ensure_filelike
+
+            with ensure_filelike(file, mode="w+b") as out:
+                out.write(packb(self.to_keyed_chain()))
+            return None
+        return packb(self.to_keyed_chain())
+
+    @classmethod
+    def from_msgpack(cls, file: Optional[PathLike | TextIO] = None, content: Optional[bytes] = None):
+        # TODO: docstring
+
+        # need to import here to avoid circular import
+        from gufe.custom_msgpack import unpackb
+
+        if content is not None and file is not None:
+            raise ValueError("Cannot specify both `content` and `file`; only one input allowed")
+        elif content is None and file is None:
+            raise ValueError("Must specify either `content` and `file` for MessagePack input")
+
+        if content is not None:
+            keyed_chain = unpackb(content)
+        else:
+            from gufe.utils import ensure_filelike
+
+            with ensure_filelike(file, mode="rb") as f:
+                keyed_chain = unpackb(f.read())
+
+        return cls.from_keyed_chain(keyed_chain=keyed_chain)
+
 
 class GufeKey(str):
     def __repr__(self):  # pragma: no cover


### PR DESCRIPTION
This PR implements custom [MessagePack](https://msgpack.org/index.html) serialization and deserialization using [`msgpack-python`](https://github.com/msgpack/msgpack-python).

It adds a new module, `gufe.custom_msgpack`, which provides the `packb` and `unpackb` for packing and unpacking MessagePack-encoded bytes with custom Extension types.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
