### PR TITLE
[DNM] Prototype using pablo to load pdb files

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,5 +24,8 @@ dependencies:
   - pydata-sphinx-theme
   - sphinx-jsonschema==1.15
   - sphinx <7.1.2
+  # For pablo testing
+  - pyxdg
   - pip:
     - autodoc_pydantic<2.0.0
+    - git+https://github.com/openforcefield/openff-pablo.git@v0.0.1a1


### PR DESCRIPTION
This is a quick investigation into using pablo to load pdb files for the protein components.

# Notes
- due to openff topology having a nice interface to openmm topology the changes needed to load pdb files are minimal 
- comparing the topology created by loading from openmm vs pablo are different (this just seems to be extra information like bond orders etc are added by Pablo)
- pdbx and mmcif are not supported yet
- Some tests fail, we should look into if this is a pablo issue or an issue with the files
- we should make sure we can load all of the industry benchmark systems with pablo to have parity with the current loader.

#Questions

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
