### PR TITLE
Fix typo in visualization

### DIFF
--- a/gufe/visualization/mapping_visualization.py
+++ b/gufe/visualization/mapping_visualization.py
@@ -158,7 +158,7 @@ def _draw_molecules(
 
     # standard settings for our visualization
     d2d.drawOptions().useBWAtomPalette()
-    d2d.drawOptions().continousHighlight = False
+    d2d.drawOptions().continuousHighlight = False
     d2d.drawOptions().setHighlightColour(highlight_color)
     d2d.drawOptions().addAtomIndices = True
     d2d.DrawMolecules(

--- a/news/issue-541.rst
+++ b/news/issue-541.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixes a typo in the gufe 2D visualization code which affected bond highlighting.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Fixes #541 

Looking at the rdkit changelog, I suspect bond highlighting was actually not working properly before (and that rdkit just wasn't tripping on the attribute error because of some C++ / Python interface issue).

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
