### PR TITLE
Move data to zenodo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - openmm >=8.2
   - pint
   - pip
+  - pooch
   - pydantic >1
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - networkx
   - numpy
   - openff-toolkit >=0.15.1
-  - openff-units >=0.3.1
+  - openff-units >=0.3.0
   - openmm >=8.2
   - pint
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - networkx
   - numpy
   - openff-toolkit >=0.15.1
-  - openff-units >=0.3.0
+  - openff-units >=0.3.1
   - openmm >=8.2
   - pint
   - pip

--- a/gufe/tests/conftest.py
+++ b/gufe/tests/conftest.py
@@ -27,7 +27,7 @@ else:
 try:
     from openmm import Platform
 
-    OPENMM_VERSION = Version(Platform.getOpenMMVersion())
+    OPENMM_VERSION: Version | None = Version(Platform.getOpenMMVersion())
 # Support OpenMM as a soft dep
 except ModuleNotFoundError:
     OPENMM_VERSION = None

--- a/gufe/tests/conftest.py
+++ b/gufe/tests/conftest.py
@@ -1,11 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/gufe
 
-import functools
 import importlib.resources
-import io
-import urllib.request
-from urllib.error import URLError
 
 import pooch
 import pytest

--- a/gufe/tests/conftest.py
+++ b/gufe/tests/conftest.py
@@ -27,10 +27,11 @@ else:
 try:
     from openmm import Platform
 
-    OPENMM_VERSION: Version | None = Version(Platform.getOpenMMVersion())
+    OPENMM_VERSION = Version(Platform.getOpenMMVersion())
 # Support OpenMM as a soft dep
+# Set it to version 0.0.0 if it isn't installed
 except ModuleNotFoundError:
-    OPENMM_VERSION = None
+    OPENMM_VERSION = Version("0.0.0")
 
 
 class URLFileLike:

--- a/gufe/tests/conftest.py
+++ b/gufe/tests/conftest.py
@@ -67,9 +67,7 @@ _benchmark_pdb_names = [
 ]
 
 
-_pl_benchmark_url_pattern = (
-    "https://github.com/OpenFreeEnergy/openfe-benchmarks/blob/main/openfe_benchmarks/data/{name}.pdb?raw=true"
-)
+_pl_benchmark_url_pattern = "https://github.com/OpenFreeEnergy/openfe-benchmarks/tree/f577a88d94b6deae1c0de7eb926edf48dd42b72d/openfe_benchmarks/data/{name}.pdb?raw=true"
 
 
 PDB_BENCHMARK_LOADERS = {

--- a/gufe/tests/test_proteincomponent.py
+++ b/gufe/tests/test_proteincomponent.py
@@ -180,7 +180,7 @@ class TestProteinComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComponentM
 
     @pytest.mark.parametrize("input_type", ["filename", "Path", "StringIO", "TextIOWrapper"])
     @pytest.mark.skipif(OPENMM_VERSION < Version("8.2"), reason="OpenMM version too old")
-    @pytest.mark.skipif(not OPENMM_VERSION, reason="OpenMM not installed")
+    @pytest.mark.skipif(OPENMM_VERSION == Version("0.0.0"), reason="OpenMM not installed")
     def test_to_pdb_input_types(self, PDB_181L_path, tmp_path, input_type):
         p = self.cls.from_pdb_file(str(PDB_181L_path), name="Bob")
 
@@ -192,7 +192,7 @@ class TestProteinComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComponentM
         )
 
     @pytest.mark.parametrize("in_pdb_path", ALL_PDB_LOADERS.keys())
-    @pytest.mark.skipif(not OPENMM_VERSION, reason="OpenMM not installed")
+    @pytest.mark.skipif(OPENMM_VERSION == Version("0.0.0"), reason="OpenMM not installed")
     def test_to_pdb_round_trip(self, in_pdb_path, tmp_path):
         in_pdb_io = ALL_PDB_LOADERS[in_pdb_path]()
 


### PR DESCRIPTION
Host the data on zenodo as we get 403 errors from github sometimes.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
