### PR TITLE
Fix conda-cron: add pooch to test dependencies

### DIFF
--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: install gufe and deps
         run: |
-          micromamba install gufe pytest pytest-xdist pip -c conda-forge
+          micromamba install gufe pooch pytest pytest-xdist pip -c conda-forge
           python -m pip install PyGithub
 
       - id: run-tests


### PR DESCRIPTION
It's all in the title.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
