### PR TITLE
Fix package build python version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
           cache-environment: true
           cache-downloads: true
           create-args: >-
-            python=${{ matrix.python-version }}
+            python=3.12
           init-shell: bash
 
       - name: "install extra deps"


### PR DESCRIPTION
It's not on a matrix, so there's not python version being passed.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
