### PR TITLE
add tests for settings models

### DIFF
--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -37,7 +37,7 @@ class SettingsBaseModel(DefaultModel):
         :noindex:
         """
 
-        extra = pydantic.Extra.forbid
+        extra = 'forbid'
         arbitrary_types_allowed = False
         smart_union = True
 
@@ -141,11 +141,6 @@ class OpenMMSystemGeneratorFFSettings(BaseForceFieldSettings):
     .. _`OpenMMForceField SystemGenerator documentation`:
        https://github.com/openmm/openmmforcefields#automating-force-field-management-with-systemgenerator
     """
-
-    class Config:
-        """:noindex:"""
-
-        pass
 
     constraints: str | None = "hbonds"
     """Constraints to be applied to system.

--- a/gufe/tests/test_models.py
+++ b/gufe/tests/test_models.py
@@ -78,7 +78,6 @@ def test_json_round_trip(all_settings_path, tmp_path):
 
     assert settings == Settings.parse_raw(settings_from_file)
 
-
 def test_default_settings():
     my_settings = Settings.get_defaults()
     my_settings.thermo_settings.temperature = 298 * unit.kelvin
@@ -105,6 +104,27 @@ class TestOpenMMSystemGeneratorFFSettings:
         else:
             with pytest.raises(ValueError):
                 _ = OpenMMSystemGeneratorFFSettings(constraints=value)
+
+    @pytest.mark.parametrize(
+        "value,valid,expected",
+        [
+            (1.0 * unit.nanometer, True, 1.0 * unit.nanometer),
+            (1.0, True, 1.0 * unit.nanometer),  # should cast float to nanometer
+            ("1.1 nm", True, 1.1 * unit.nanometer),
+            ("1.1 ", False, None),
+            # (1.0 * unit.angstrom, True, 0.100 * unit.nanometer),  # TODO: why does this not work?
+            (300 * unit.kelvin, False, None),
+            (True, False, None),
+            # ("one", False, None),  # TODO: more elegant error handling for this
+        ],
+    )
+    def test_nonbonded_cutoff_validation(self, value, valid, expected):
+        if valid:
+            s = OpenMMSystemGeneratorFFSettings(nonbonded_cutoff=value)
+            assert s.nonbonded_cutoff == expected
+        else:
+            with pytest.raises(ValueError):
+                _ = OpenMMSystemGeneratorFFSettings(nonbonded_cutoff=value)
 
 
 class TestFreezing:

--- a/gufe/tests/test_models.py
+++ b/gufe/tests/test_models.py
@@ -112,6 +112,8 @@ class TestOpenMMSystemGeneratorFFSettings:
             (1.0, True, 1.0 * unit.nanometer),  # should cast float to nanometer
             ("1.1 nm", True, 1.1 * unit.nanometer),
             ("1.1 ", False, None),
+            (0, True, 0*unit.nanometer),
+            (-1.0 *unit.nanometer, False, None),
             # (1.0 * unit.angstrom, True, 0.100 * unit.nanometer),  # TODO: why does this not work?
             (300 * unit.kelvin, False, None),
             (True, False, None),

--- a/gufe/tests/test_models.py
+++ b/gufe/tests/test_models.py
@@ -12,11 +12,56 @@ from openff.units import unit
 from gufe.settings.models import OpenMMSystemGeneratorFFSettings, Settings, ThermoSettings
 
 
-def test_model_schema():
-    Settings.schema_json(indent=2)
+def test_settings_schema():
+    """Settings schema should be stable"""
+    expected_schema = {
+        "title": "Settings",
+        "description": "Container for all settings needed by a protocol\n\nThis represents the minimal surface that all settings objects will have.\n\nProtocols can subclass this to extend this to cater for their additional settings.",
+        "type": "object",
+        "properties": {
+            "forcefield_settings": {"$ref": "#/definitions/BaseForceFieldSettings"},
+            "thermo_settings": {"$ref": "#/definitions/ThermoSettings"},
+        },
+        "required": ["forcefield_settings", "thermo_settings"],
+        "additionalProperties": False,
+        "definitions": {
+            "BaseForceFieldSettings": {
+                "title": "BaseForceFieldSettings",
+                "description": "Base class for ForceFieldSettings objects",
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+            "ThermoSettings": {
+                "title": "ThermoSettings",
+                "description": "Settings for thermodynamic parameters.\n\n.. note::\n   No checking is done to ensure a valid thermodynamic ensemble is\n   possible.",
+                "type": "object",
+                "properties": {
+                    "temperature": {
+                        "title": "Temperature",
+                        "description": "Simulation temperature, default units kelvin",
+                        "type": "number",
+                    },
+                    "pressure": {
+                        "title": "Pressure",
+                        "description": "Simulation pressure, default units standard atmosphere (atm)",
+                        "type": "number",
+                    },
+                    "ph": {"title": "Ph", "description": "Simulation pH", "exclusiveMinimum": 0, "type": "number"},
+                    "redox_potential": {
+                        "title": "Redox Potential",
+                        "description": "Simulation redox potential",
+                        "type": "number",
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+    }
+    schema = Settings.schema()
+    assert schema == expected_schema
 
-
-@pytest.mark.xfail  # issue #125
+@pytest.mark.xfail  # issue #125  TODO: update this now that files are vendored
 def test_json_round_trip(all_settings_path, tmp_path):
     with open(all_settings_path) as fd:
         settings = Settings.parse_raw(fd.read())

--- a/gufe/tests/test_models.py
+++ b/gufe/tests/test_models.py
@@ -86,23 +86,25 @@ def test_default_settings():
     my_settings.schema_json(indent=2)
 
 
-@pytest.mark.parametrize(
-    "value,good",
-    [
-        ("parsnips", False),  # shouldn't be allowed
-        ("hbonds", True),
-        ("hangles", True),
-        ("allbonds", True),  # allowed options
-        ("HBonds", True),  # check case insensitivity
-    ],
-)
-def test_invalid_constraint(value, good):
-    if good:
-        s = OpenMMSystemGeneratorFFSettings(constraints=value)
-        assert s
-    else:
-        with pytest.raises(ValueError):
-            _ = OpenMMSystemGeneratorFFSettings(constraints=value)
+class TestOpenMMSystemGeneratorFFSettings:
+    @pytest.mark.parametrize(
+        "value,valid,expected",
+        [
+            ("parsnips", False, None),  # shouldn't be allowed
+            ("hbonds", True, "hbonds"),
+            ("hangles", True, "hangles"),
+            ("allbonds", True, "allbonds"),  # allowed options
+            ("HBonds", True, "HBonds"),  # check case insensitivity TODO: cast this to lower?
+            (None, True, None),
+        ],
+    )
+    def test_constraints_validation(self, value, valid, expected):
+        if valid:
+            s = OpenMMSystemGeneratorFFSettings(constraints=value)
+            assert s.constraints == expected
+        else:
+            with pytest.raises(ValueError):
+                _ = OpenMMSystemGeneratorFFSettings(constraints=value)
 
 
 class TestFreezing:
@@ -114,7 +116,7 @@ class TestFreezing:
         s.thermo_settings.temperature = 199 * unit.kelvin
         assert s.thermo_settings.temperature == 199 * unit.kelvin
 
-    def test_freezing(self):
+    def test_default_frozen(self):
         s = Settings.get_defaults()
 
         s2 = s.frozen_copy()


### PR DESCRIPTION
ahead of migrating to pydantic v2, we should have some more thorough tests of the settings models.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
