### PR TITLE
Ensure PEP-639 Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ license = "MIT"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Bio-Informatics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ description = ""
 readme = "README.md"
 authors = [{name = "The OpenFE developers", email = "openfe@omsf.io"}]
 license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dynamic = ["version"]
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-license-files = ["LICENSE"]
 
 [tool.setuptools.packages]
 find = {namespaces = false}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-	"setuptools>=61.2",
+	"setuptools>=77.0.3",
 	"versioningit",
 ]
 build-backend = "setuptools.build_meta"
@@ -10,7 +10,7 @@ name = "gufe"
 description = ""
 readme = "README.md"
 authors = [{name = "The OpenFE developers", email = "openfe@omsf.io"}]
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
Eventually (2026-Feb-18) the license field needs to be a SPDX license expression. The table with a "file" or "text" key is deprecated. As of version 77.0.3, setuptools supports this new format.

See:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
