### PR TITLE
Update the default nonbonded cutoff

### DIFF
--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -169,7 +169,7 @@ class OpenMMSystemGeneratorFFSettings(BaseForceFieldSettings):
     # TODO: currently, serialization scheme doesn't work for default values, will be fixed in pydantic v2.12
     # see https://github.com/pydantic/pydantic/issues/11446
     nonbonded_cutoff: Annotated[NanometerQuantity, Ge(0)] = Field(
-        default=1.0 * unit.nanometer, description="Cutoff value for short range nonbonded interactions."
+        default=0.9 * unit.nanometer, description="Cutoff value for short range nonbonded interactions."
     )
 
     @field_validator("nonbonded_method", mode="after")


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Update the nonbonded cutoff to 0.9 nanometers to match the OpenFF default. Related to https://github.com/OpenFreeEnergy/openfe/pull/1523 


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
