### PR TITLE
Replace dict call with `model_dump` in `_ipython_display_` of SettingsBaseModel

### DIFF
--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -27,7 +27,7 @@ class SettingsBaseModel(_BaseModel):
     )
 
     def _ipython_display_(self):
-        pprint.pprint(self.dict())
+        pprint.pprint(self.model_dump())
 
     def frozen_copy(self):
         """A copy of this Settings object which cannot be modified


### PR DESCRIPTION
Deprecation was a bit annoying is all.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
