### PR TITLE
[DNM] Enable source link display in HTML documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,7 @@ autodoc_mock_imports = [
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
+html_show_sourcelink = True
 html_theme = "furo"
 # html_theme_options = {
 #    "accent_color": "FeelingFabulous",


### PR DESCRIPTION
Just trying something out.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
