### PR TITLE
run ci on all PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,10 @@ on:
   # Allow for workflows to be manuallly triggered
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
+      - release
   schedule:
     # At 07:00 UTC on Monday and Thursday.
     - cron: "0 7 * * *"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

gufe CI is pretty quick, so I think it makes sense to run it on a PR into any branch. Also, I'm trying out using a `stable` branch to make bugfix releases smoother, and I definitely want CI to run on that.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
