### PR TITLE
membrane prototype suggestion: use openff units codec when serializing box vectors

### DIFF
--- a/gufe/components/proteincomponent.py
+++ b/gufe/components/proteincomponent.py
@@ -924,13 +924,9 @@ class SolvatedPDBComponent(ProteinComponent, BaseSolventComponent):
         array plus unit string.
         """
         d = super()._to_dict()
-
         box = self.box_vectors.to("nanometer")
 
-        d["box_vectors"] = {
-            "value": serialize_numpy(box.m),
-            "unit": str(box.units),
-        }
+        d["box_vectors"] = box
 
         return d
 
@@ -939,26 +935,16 @@ class SolvatedPDBComponent(ProteinComponent, BaseSolventComponent):
         """
         Deserialize from a dictionary.
         """
-        box_data = d.get("box_vectors")
-        if box_data is None:
+        box_vectors = d.get("box_vectors")
+        if box_vectors is None:
             raise ValueError("box_vectors must be present in the serialized dict")
 
         prot = ProteinComponent._from_dict(d.copy(), name=name)
 
-        # If it already is a Quantity (e.g. from copy_with_replacements)
-        if hasattr(box_data, "units"):
-            box = box_data
-
-        # If it comes from the serialized form (e.g. _to_dict)
-        else:
-            unit_name = box_data["unit"]
-            unit_obj = getattr(offunit, unit_name)
-            box = deserialize_numpy(box_data["value"]) * unit_obj
-
         return cls(
             rdkit=prot._rdkit,
             name=prot.name,
-            box_vectors=box,
+            box_vectors=box_vectors,
         )
 
 

--- a/gufe/tests/test_proteincomponent.py
+++ b/gufe/tests/test_proteincomponent.py
@@ -395,7 +395,6 @@ class TestSolvatedPDBComponent(GufeTokenizableTestsMixin, ExplicitMoleculeCompon
             )
 
     def test_missing_box_vectors_raises(self, PDB_181L_path):
-
         with pytest.raises(ValueError, match="Could not determine box_vectors"):
             self.cls.from_pdb_file(PDB_181L_path)
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
