### PR TITLE
Closes #583: ProtocolUnits list missing units in Protocol._create is ok?

### DIFF
--- a/gufe/protocols/__init__.py
+++ b/gufe/protocols/__init__.py
@@ -3,6 +3,7 @@
 from .errors import (
     GufeProtocolError,
     MissingUnitResultError,
+    ProtocolDAGError,
     ProtocolDAGResultError,
     ProtocolUnitExecutionError,
     ProtocolUnitFailureError,

--- a/gufe/protocols/errors.py
+++ b/gufe/protocols/errors.py
@@ -15,6 +15,10 @@ class ProtocolUnitExecutionError(GufeProtocolError):
     """Error when executing a protocol unit."""
 
 
+class ProtocolDAGError(GufeProtocolError):
+    """Error when constructing or validating a ProtocolDAG."""
+
+
 # Protocol Results Errors
 class ProtocolDAGResultError(GufeProtocolError):
     """Base error when dealing with DAG results."""

--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -14,7 +14,7 @@ from typing import Any, Optional, Union
 import networkx as nx
 
 from ..tokenization import GufeKey, GufeTokenizable
-from .errors import MissingUnitResultError, ProtocolUnitFailureError
+from .errors import MissingUnitResultError, ProtocolDAGError, ProtocolUnitFailureError
 from .protocolunit import Context, ProtocolUnit, ProtocolUnitFailure, ProtocolUnitResult
 
 
@@ -346,6 +346,17 @@ class ProtocolDAG(GufeTokenizable, DAGMixin):
 
         # build graph from protocol units
         self._graph = self._build_graph(protocol_units)
+
+        # validate that all units in the graph were explicitly provided
+        provided_units = set(protocol_units)
+        graph_units = set(self._graph.nodes)
+        missing_units = graph_units - provided_units
+        if missing_units:
+            raise ProtocolDAGError(
+                f"ProtocolDAG contains units that were not explicitly provided: "
+                f"{missing_units}. All units must be passed explicitly via `protocol_units`, "
+                f"even if they are dependencies of other units."
+            )
 
     @classmethod
     def _defaults(cls):

--- a/gufe/tests/test_protocoldag.py
+++ b/gufe/tests/test_protocoldag.py
@@ -145,3 +145,28 @@ def test_execute_dag(tmpdir, keep_shared, keep_scratch, writefile_dag, capture_s
         # check that our shared and scratch basedirs are left behind
         assert shared.exists()
         assert scratch.exists()
+
+
+def test_protocoldag_missing_dependency_unit():
+    """Test that ProtocolDAG raises an error when units with dependencies
+    are provided but their dependencies are not explicitly included.
+
+    This test addresses issue #583: Protocol._create should return all units,
+    not rely on implicit dependency discovery.
+    """
+    # Create a setup unit that other units depend on
+    setup_unit = WriterUnit(identity=0, name="setup")
+
+    # Create units that depend on the setup unit
+    dependent_units = [
+        WriterUnit(identity=i, setup=setup_unit, name=f"cycle_{i}")
+        for i in range(1, 4)
+    ]
+
+    # Attempt to create a ProtocolDAG without including the setup_unit
+    # This should raise a ProtocolDAGError
+    with pytest.raises(gufe.protocols.ProtocolDAGError, match="units that were not explicitly provided"):
+        gufe.ProtocolDAG(
+            protocol_units=dependent_units,  # Missing setup_unit!
+            transformation_key=None,
+        )

--- a/gufe/tests/test_protocoldag.py
+++ b/gufe/tests/test_protocoldag.py
@@ -158,10 +158,7 @@ def test_protocoldag_missing_dependency_unit():
     setup_unit = WriterUnit(identity=0, name="setup")
 
     # Create units that depend on the setup unit
-    dependent_units = [
-        WriterUnit(identity=i, setup=setup_unit, name=f"cycle_{i}")
-        for i in range(1, 4)
-    ]
+    dependent_units = [WriterUnit(identity=i, setup=setup_unit, name=f"cycle_{i}") for i in range(1, 4)]
 
     # Attempt to create a ProtocolDAG without including the setup_unit
     # This should raise a ProtocolDAGError

--- a/news/fix-protocol-create-missing-units.rst
+++ b/news/fix-protocol-create-missing-units.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* a ``ProtocolDAG`` created with ``ProtocolUnit``\s not explicitly represented on init now raises ``ProtocolDAGError`` (#583)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #583.

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
