### PR TITLE
Document logging mechanism for GufeTokenizables and Protocols

### DIFF
--- a/docs/concepts/index.rst
+++ b/docs/concepts/index.rst
@@ -12,3 +12,4 @@ utilize **gufe** APIs.
    tokenizables
    included_models
    serialization
+   logging

--- a/docs/concepts/logging.rst
+++ b/docs/concepts/logging.rst
@@ -1,0 +1,173 @@
+.. _understanding_logging:
+
+Logging in ``GufeTokenizable``\s
+=================================
+
+All :class:`.GufeTokenizable` objects in **gufe** have built-in logging support through the ``logger`` property.
+This logging mechanism is designed to make debugging and runtime introspection easier by automatically tagging log messages with the object's :class:`.GufeKey`.
+
+Basic Usage
+-----------
+
+Every ``GufeTokenizable`` has a ``logger`` property that returns a :class:`logging.LoggerAdapter` configured specifically for that instance:
+
+.. code-block:: python
+
+    from gufe import SolventComponent
+
+    sc = SolventComponent()
+    sc.logger.info("Creating solvent component")
+    sc.logger.debug("Detailed information about the component")
+    sc.logger.warning("Something to be aware of")
+    sc.logger.error("An error occurred")
+
+How It Works
+------------
+
+The logging system uses Python's standard :mod:`logging` module with a custom :class:`logging.LoggerAdapter`.
+Each ``GufeTokenizable`` instance gets its own logger adapter that automatically adds the object's ``GufeKey`` to the logging context.
+
+Logger Naming
+^^^^^^^^^^^^^
+
+Loggers are named hierarchically based on the object's module and class:
+
+.. code-block:: python
+
+    gufekey.<module>.<qualname>
+
+For example, a :class:`.SolventComponent` has the logger name:
+
+.. code-block:: python
+
+    gufekey.gufe.components.solventcomponent.SolventComponent
+
+This hierarchical naming allows you to control logging at different levels of granularity (e.g., all ``gufe`` objects, all components, or just ``SolventComponent`` instances).
+
+GufeKey in Log Messages
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The logger adapter adds a ``gufekey`` field to each log record, containing the full :class:`.GufeKey` of the object (e.g., ``SolventComponent-26b4034ad9dbd9f908dfc298ea8d449f``).
+
+This allows you to use ``%(gufekey)s`` in your logging formatters to include the object's key in log messages.
+
+Configuring Logging
+-------------------
+
+To see log messages from **gufe** objects, you need to configure the Python logging system.
+Here's a complete example:
+
+.. code-block:: python
+
+    import logging
+    import time
+    from gufe import SolventComponent
+
+    # Get the root logger for all gufe objects
+    logger = logging.getLogger('gufekey')
+
+    # Create a formatter that includes the GufeKey
+    formatter = logging.Formatter(
+        "[%(asctime)s] [%(gufekey)s] [%(levelname)s] %(message)s"
+    )
+    formatter.converter = time.gmtime  # Use UTC time for timestamps
+
+    # Create a handler and attach the formatter
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    # Add the handler to the logger and set the level
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    # Now log messages will be visible
+    sc = SolventComponent()
+    sc.logger.info("Solvent component created")
+
+This produces output like:
+
+.. code-block:: text
+
+    [2025-10-29 23:36:27,220] [SolventComponent-26b4034ad9dbd9f908dfc298ea8d449f] [INFO] Solvent component created
+
+Logging Levels
+--------------
+
+The standard Python logging levels apply:
+
+* ``DEBUG``: Detailed diagnostic information
+* ``INFO``: General informational messages
+* ``WARNING``: Warning messages for potentially problematic situations
+* ``ERROR``: Error messages for serious problems
+* ``CRITICAL``: Critical messages for very serious errors
+
+You control which messages appear by setting the logger level:
+
+.. code-block:: python
+
+    # Show only warnings and errors
+    logger.setLevel(logging.WARNING)
+
+    # Show everything, including debug messages
+    logger.setLevel(logging.DEBUG)
+
+Best Practices
+--------------
+
+1. **Use appropriate log levels**: Reserve ``DEBUG`` for detailed diagnostic information, ``INFO`` for general progress updates, and ``WARNING``/``ERROR`` for problems.
+
+2. **Don't check verbosity flags**: Unlike some older patterns, you should not check verbosity settings before logging.
+   Instead, log freely at the appropriate level and let the logging configuration control what gets shown.
+
+   .. code-block:: python
+
+       # Good - just log at the appropriate level
+       self.logger.debug("Detailed information")
+       self.logger.info("Progress update")
+
+       # Bad - don't do this
+       if verbose:
+           self.logger.info("Progress update")
+
+3. **Configure at execution time**: The user or execution engine should configure logging levels when running code, not the library code itself.
+
+4. **Use the GufeKey in formatters**: Include ``%(gufekey)s`` in your log formatters to track which object generated each message.
+   This is especially useful when many objects are logging simultaneously.
+
+5. **Log to the object's logger**: Always use ``self.logger`` within your ``GufeTokenizable`` methods, not a module-level logger or ``print()`` statements.
+
+Advanced: Hierarchical Logger Control
+--------------------------------------
+
+Because logger names are hierarchical, you can control logging at different levels of specificity:
+
+.. code-block:: python
+
+    # Control all gufe logging
+    logging.getLogger('gufekey').setLevel(logging.INFO)
+
+    # Control only Protocol logging
+    logging.getLogger('gufekey.gufe.protocols').setLevel(logging.DEBUG)
+
+    # Control only a specific Protocol subclass
+    logging.getLogger('gufekey.gufe.protocols.protocolunit').setLevel(logging.WARNING)
+
+This allows fine-grained control over which objects produce log output without modifying the code itself.
+
+Note: Logger Initialization Timing
+-----------------------------------
+
+When a ``GufeTokenizable`` is first created, its ``GufeKey`` may not yet be computed.
+If you log a message before the key is available, the ``gufekey`` field will show ``"UNKNOWN"`` instead of the actual key.
+
+.. code-block:: python
+
+    class MyComponent(GufeTokenizable):
+        def __init__(self, value):
+            # This logs before the key is computed
+            self.logger.info("Starting initialization")  # Shows "UNKNOWN"
+            self.value = value
+            # This logs after the key is computed
+            self.logger.info("Initialization complete")  # Shows actual GufeKey
+
+In practice, this is rarely an issue since most logging happens after initialization is complete.

--- a/docs/concepts/logging.rst
+++ b/docs/concepts/logging.rst
@@ -49,7 +49,7 @@ GufeKey in Log Messages
 
 The logger adapter adds a ``gufekey`` field to each log record, containing the full :class:`.GufeKey` of the object (e.g., ``SolventComponent-26b4034ad9dbd9f908dfc298ea8d449f``).
 
-This allows you to use ``%(gufekey)s`` in your logging formatters to include the object's key in log messages.
+This allows you to use ``%(gufekey)s`` in your `logging formatters <https://docs.python.org/3/library/logging.html#logging.Formatter>`_ to include the object's key in log messages.
 
 Configuring Logging
 -------------------

--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -438,7 +438,7 @@ class TestGufeTokenizable(GufeTokenizableTestsMixin):
         leaf = Leaf(10)
 
         results = stream.getvalue()
-        key = leaf.key.split("-")[-1]
+        key = str(leaf.key)
 
         initial_log = f"{name} - UNKNOWN - INFO - no key defined!\n"
         info_log = f"{name} - {key} - INFO - a=10\n"

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -124,7 +124,7 @@ class _GufeLoggerAdapter(logging.LoggerAdapter):
         extra = kwargs.get("extra", {})
         if (extra_dict := getattr(self, "_extra_dict", None)) is None:
             try:
-                gufekey = self.extra.key.split("-")[-1]
+                gufekey = str(self.extra.key)
             except Exception:
                 # no matter what happened, we have a bad key
                 gufekey = "UNKNOWN"


### PR DESCRIPTION
## Summary

This PR addresses #411 and #579 by documenting the logging mechanism for `GufeTokenizable` objects and providing clear guidance for protocol authors on how to effectively use logging.

### Changes Made

1. **Updated `_GufeLoggerAdapter` to show full `GufeKey`** (gufe/tokenization.py)
   - Changed from showing just the MD5 token to showing the full `GufeKey` (e.g., `SolventComponent-26b4034ad9dbd9f908dfc298ea8d449f`)
   - This makes logs more informative and easier to interpret

2. **Created comprehensive logging concept documentation** (docs/concepts/logging.rst)
   - Explains how the logging system works for all `GufeTokenizable` objects
   - Demonstrates proper logging configuration
   - Provides best practices for logging in gufe code
   - Explains the hierarchical logger naming scheme
   - Documents the `gufekey` formatter field

3. **Added logging section to Protocol how-to** (docs/how-tos/protocol.rst)
   - Explains how to use logging in `ProtocolUnit` classes
   - Emphasizes using appropriate log levels (DEBUG, INFO, WARNING, ERROR)
   - **Key principle**: Don't check verbosity flags; log freely and let the logging configuration control what gets shown
   - Provides examples of proper logging in protocol code
   - Shows how users can configure logging when executing protocols

4. **Updated test to match new behavior** (gufe/tests/test_tokenization.py)
   - Test now expects full `GufeKey` instead of just the token

5. **Fixed bugs in Protocol documentation examples**
   - Removed `@staticmethod` decorator from methods that use `self.logger`
   - Fixed variable name bugs (`window` → `lambda_window`)

### Resolves

- Closes #411 - Document explicit mechanism for Protocol logging
- Closes #579 - How to handle logging in a protocol

### Key Principles for Protocol Authors

The documentation emphasizes:
1. **Log freely at appropriate levels** - Don't implement custom verbosity checks
2. **Use standard Python logging levels** - DEBUG for details, INFO for progress, WARNING/ERROR for problems
3. **Let users control logging** - Logging configuration should happen at execution time, not in the protocol code
4. **Use the `gufekey` formatter field** - This allows tracking which object generated each log message

### Test Plan

- Updated existing logging test to verify full `GufeKey` appears in logs
- Documentation can be built and verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)