### PR TITLE
docs: add information on using keyed chain for serialization to disk

### DIFF
--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -180,31 +180,21 @@ Deduplication on disk
 ~~~~~~~~~~~~~~~~~~~~~
 
 Deduplication when writing a GufeTokenizable to disk can be handled by :ref:`to_keyed_chain() <keyed_chain>`, which serializes and de-duplicates an entire chain of tokenizable objects to disk in a single file.
-However, **gufe** provides no tooling for deduplicating across chains stored to disk and it is up to the storage system to implement its own registry for handling this.
 
-The main idea is to use the ``GufeKey`` to ensure uniqueness, and to use it as a label for the object's serialized representation.
-Additionally, the ``GufeKey``, which is simply a string, can be used as a stand-in for the object.
-When an outer ``GufeTokenizable`` contains an inner ``GufeTokenizable``, the outer can store the ``GufeKey`` in place of the inner object.
-
-
-To convert a ``GufeTokenizable`` ``obj`` into a dictionary that references inner ``GufeTokenizable``\s by ``GufeKey``, use ``obj.to_keyed_dict()``.
-That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, ``':gufe-key:'``, mapping to the ``GufeKey`` of the object.
+**gufe** provides no tooling for deduplicating across chains stored to disk and it is up to the storage system to implement its own registry for handling this.
 However, you take advantage of **gufe** functionality to facilitate system-specific deduplication.
 
-You can use :ref:`keyed dict <keyed_dict>` to represent``GufeTokenizable`` ``obj`` as a ``dict`` that references inner ``GufeTokenizable``\s by their``GufeKey``\s, and repeat this recursively to store (with the disk storage method of your choosing) all objects by reference.
-Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outermost ``obj``\s.
-
+You can use :ref:`keyed dict <keyed_dict>` to represent a ``GufeTokenizable`` object as a ``dict`` that references inner ``GufeTokenizable``\s by their ``GufeKey``\s, and repeat this recursively to store (with the disk storage method of your choosing) all objects by reference.
+Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outermost objects.
 
 If you don't need the level of granularity that keyed dict representation offers, :ref:`keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
-It is important to note that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use ``to_keyed_chain()``  under the hood to make
-serialization to disk and over the network possible. When you want to load this object back into memory, you would use something
-like ``obj.from_json()`` or ``obj.to_json()`` to handle serialization back into the correct structure.
-.. TODO: add a tutorial for this in the tutorials section?
-
+It is important to note that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use ``to_keyed_chain()`` under the hood to make
+serialization to disk and over the network possible.
+When you want to load this object back into memory, you would use something like ``obj.from_json()`` or ``obj.to_json()`` to handle serialization back into the correct structure.
 
 .. _serialization:
 
-3. Serializable Representations of ``GufeTokenizable``\s
+1. Serializable Representations of ``GufeTokenizable``\s
 --------------------------------------------------------
 
 ``GufeTokenizable``\s are also designed to be easily serializable, allowing them to be reliably passed between processes on the same or different machines, written to disk, stored in databases, etc. There are multiple *serialization* methods available, and a variety of *representations* ``GufeTokenizable``\s can take on, to meet different use cases.

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -191,11 +191,11 @@ To convert a ``GufeTokenizable`` ``obj`` into a dictionary that references inner
 That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, ``':gufe-key:'``, mapping to the ``GufeKey`` of the object.
 However, you take advantage of **gufe** functionality to facilitate system-specific deduplication.
 
-You can use `:ref:`keyed dict <keyed_dict>` to represent``GufeTokenizable`` ``obj`` as a ``dict`` that references inner ``GufeTokenizable``\s by their``GufeKey``\s, and repeat this recursively to store (with the disk storage method of your choosing) all objects by reference.
+You can use :ref:`keyed dict <keyed_dict>` to represent``GufeTokenizable`` ``obj`` as a ``dict`` that references inner ``GufeTokenizable``\s by their``GufeKey``\s, and repeat this recursively to store (with the disk storage method of your choosing) all objects by reference.
 Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outermost ``obj``\s.
 
 
-If you don't need the level of granularity that keyed dict representation offers, `:ref:`keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
+If you don't need the level of granularity that keyed dict representation offers, `:ref:keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
 
 
 ``obj.to_keyed_chain()`` does exactly that. It handles the correct serailzization of all subparts.

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -189,7 +189,7 @@ That is, we can store by reference to the ``GufeKey``.
 
 To convert a ``GufeTokenizable`` ``obj`` into a dictionary that references inner ``GufeTokenizable``\s by ``GufeKey``, use ``obj.to_keyed_dict()``.
 That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, ``':gufe-key:'``, mapping to the ``GufeKey`` of the object.
-However, you take advantage of **gufe** functionality to facilitate system-specific de-duplication.
+However, you take advantage of **gufe** functionality to facilitate system-specific deduplication.
 
 You can use `:ref:`keyed dict <keyed_dict>` to represent``GufeTokenizable`` ``obj`` as a ``dict`` that references inner ``GufeTokenizable``\s by their``GufeKey``\s, and repeat this recursively to store (with the disk storage method of your choosing) all objects by reference.
 Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outermost ``obj``\s.

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -196,9 +196,6 @@ Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outerm
 
 
 If you don't need the level of granularity that keyed dict representation offers, :ref:`keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
-
-
-``obj.to_keyed_chain()`` does exactly that. It handles the correct serialization of all sub-objects.
 It is important to note that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use ``to_keyed_chain()``  under the hood to make
 serialization to disk and over the network possible. When you want to load this object back into memory, you would use something
 like ``obj.from_json()`` or ``obj.to_json()`` to handle serialization back into the correct structure.

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -179,7 +179,7 @@ In practice, that leads to the following behavior, where ``Foo()`` is representa
 Deduplication on disk
 ~~~~~~~~~~~~~~~~~~~~~
 
-Deduplication when writing a GufeTokenizable to disk can be handled by :ref:`keyed chain <keyed_chain>`, which serializes and de-duplicates an entire chain of tokenizable objects to disk in a single file.
+Deduplication when writing a GufeTokenizable to disk can be handled by :ref:`to_keyed_chain() <keyed_chain>`, which serializes and de-duplicates an entire chain of tokenizable objects to disk in a single file.
 However, **gufe** provides no tooling for deduplicating across chains stored to disk and it is up to the storage system to implement its own registry for handling this.
 
 The main idea is to use the ``GufeKey`` to ensure uniqueness, and to use it as a label for the object's serialized representation.

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -179,8 +179,8 @@ In practice, that leads to the following behavior, where ``Foo()`` is representa
 Deduplication on disk
 ~~~~~~~~~~~~~~~~~~~~~
 
-Deduplication on disk storage is fundamentally the responsibility of the specific storage system, which falls outside the scope of **gufe**.
-However, **gufe** provides some tools to facilitate implementation of a storage system.
+Deduplication on on disk can be handled by `:ref``keyed chain <keyed_chain>` by serializing and deduplicating an entire chain of tokenizable objects to disk in a single file.
+However, **gufe** provides no tooling for deduplicating across chains stored to disk and it is up to the storage system to implement its own registry for handling this.
 
 The main idea is to use the ``GufeKey`` to ensure uniqueness, and to use it as a label for the object's serialized representation.
 Additionally, the ``GufeKey``, which is simply a string, can be used as a stand-in for the object.

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -191,6 +191,11 @@ To convert a ``GufeTokenizable`` ``obj`` into a dictionary that references inner
 That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, ``':gufe-key:'``, mapping to the ``GufeKey`` of the object.
 Of course, you'll also need to do the same for all inner ``GufeTokenizables``; to get a list of all of them, use :func:`.get_all_gufe_objs` on the outermost ``obj``.
 
+While you can implement this yourself, you can also use ``obj.to_keyed_chain()``.
+This handles iteration of the chain to and ensuring that all dependencies can be stored to disk.
+If you choose to do this, it is important to note that when reloading from the disk, you can't use ``obj.from_keyed_chain()`` because it requires
+that objects are already sorted from least-dependent to most-dependent. This cannot be guranteed when reading from disk.
+
 .. TODO: add a tutorial for this in the tutorials section?
 
 

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -189,7 +189,14 @@ That is, we can store by reference to the ``GufeKey``.
 
 To convert a ``GufeTokenizable`` ``obj`` into a dictionary that references inner ``GufeTokenizable``\s by ``GufeKey``, use ``obj.to_keyed_dict()``.
 That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, ``':gufe-key:'``, mapping to the ``GufeKey`` of the object.
-Of course, you'll also need to do the same for all inner ``GufeTokenizables``; to get a list of all of them, use :func:`.get_all_gufe_objs` on the outermost ``obj``.
+However, you take advantage of **gufe** functionality to facilitate system-specific de-duplication.
+
+You can use `:ref:`keyed dict <keyed_dict>` to represent``GufeTokenizable`` ``obj`` as a ``dict`` that references inner ``GufeTokenizable``\s by their``GufeKey``\s, and repeat this recursively to store (with the disk storage method of your choosing) all objects by reference.
+Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outermost ``obj``\s.
+
+
+If you don't need the level of granularity that keyed dict representation offers, `:ref:`keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
+
 
 ``obj.to_keyed_chain()`` does exactly that. It handles the correct serailzization of all subparts.
 It is important to note that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use ``to_keyed_chain()``  under the hood to make

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -198,7 +198,7 @@ Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outerm
 If you don't need the level of granularity that keyed dict representation offers, :ref:`keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
 
 
-``obj.to_keyed_chain()`` does exactly that. It handles the correct serailzization of all subparts.
+``obj.to_keyed_chain()`` does exactly that. It handles the correct serialization of all sub-objects.
 It is important to note that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use ``to_keyed_chain()``  under the hood to make
 serialization to disk and over the network possible. When you want to load this object back into memory, you would use something
 like ``obj.from_json()`` or ``obj.to_json()`` to handle serialization back into the correct structure.

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -191,11 +191,10 @@ To convert a ``GufeTokenizable`` ``obj`` into a dictionary that references inner
 That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, ``':gufe-key:'``, mapping to the ``GufeKey`` of the object.
 Of course, you'll also need to do the same for all inner ``GufeTokenizables``; to get a list of all of them, use :func:`.get_all_gufe_objs` on the outermost ``obj``.
 
-While you can implement this yourself, you can also use ``obj.to_keyed_chain()``.
-This handles iteration of the chain to and ensuring that all dependencies can be stored to disk.
-If you choose to do this, it is important to note that when reloading from the disk, you can't use ``obj.from_keyed_chain()`` because it requires
-that objects are already sorted from least-dependent to most-dependent. This cannot be guranteed when reading from disk.
-
+``obj.to_keyed_chain()`` does exactly that. It handles the correct serailzization of all subparts.
+It is important to not that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use this under the hood to make
+serialization to disk and over the network possible. When you want to load this object back into memory, you would use something
+like ``obj.from_json()`` or ``obj.to_json()`` to handle serialization back into the correct structure.
 .. TODO: add a tutorial for this in the tutorials section?
 
 

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -179,7 +179,7 @@ In practice, that leads to the following behavior, where ``Foo()`` is representa
 Deduplication on disk
 ~~~~~~~~~~~~~~~~~~~~~
 
-Deduplication on on disk can be handled by `:ref``keyed chain <keyed_chain>` by serializing and deduplicating an entire chain of tokenizable objects to disk in a single file.
+Deduplication on on disk can be handled by :ref:`keyed chain <keyed_chain>` by serializing and deduplicating an entire chain of tokenizable objects to disk in a single file.
 However, **gufe** provides no tooling for deduplicating across chains stored to disk and it is up to the storage system to implement its own registry for handling this.
 
 The main idea is to use the ``GufeKey`` to ensure uniqueness, and to use it as a label for the object's serialized representation.
@@ -195,7 +195,7 @@ You can use :ref:`keyed dict <keyed_dict>` to represent``GufeTokenizable`` ``obj
 Then, to get a list of all objects, use :func:`.get_all_gufe_objs` on the outermost ``obj``\s.
 
 
-If you don't need the level of granularity that keyed dict representation offers, `:ref:keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
+If you don't need the level of granularity that keyed dict representation offers, :ref:`keyed chain <keyed_chain>` does this recursive unpacking and handles the correct serialization of all nested objects.
 
 
 ``obj.to_keyed_chain()`` does exactly that. It handles the correct serailzization of all subparts.
@@ -265,6 +265,7 @@ Any nested ``GufeTokenizable``\s are left as-is.
 This representation is most useful for iterating through the hierarchy of a ``GufeTokenizable`` one layer at a time.
 Because it leaves nested ``GufeTokenizable``\s untouched, it is generally unsuitable for serialization.
 
+.. _keyed_dict:
 
 c) keyed dictionary
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -192,7 +192,7 @@ That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, `
 Of course, you'll also need to do the same for all inner ``GufeTokenizables``; to get a list of all of them, use :func:`.get_all_gufe_objs` on the outermost ``obj``.
 
 ``obj.to_keyed_chain()`` does exactly that. It handles the correct serailzization of all subparts.
-It is important to not that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use this under the hood to make
+It is important to note that functions like ``obj.to_json()`` and ``obj.to_msgpack()`` use ``to_keyed_chain()``  under the hood to make
 serialization to disk and over the network possible. When you want to load this object back into memory, you would use something
 like ``obj.from_json()`` or ``obj.to_json()`` to handle serialization back into the correct structure.
 .. TODO: add a tutorial for this in the tutorials section?

--- a/docs/concepts/tokenizables.rst
+++ b/docs/concepts/tokenizables.rst
@@ -179,13 +179,13 @@ In practice, that leads to the following behavior, where ``Foo()`` is representa
 Deduplication on disk
 ~~~~~~~~~~~~~~~~~~~~~
 
-Deduplication on on disk can be handled by :ref:`keyed chain <keyed_chain>` by serializing and deduplicating an entire chain of tokenizable objects to disk in a single file.
+Deduplication when writing a GufeTokenizable to disk can be handled by :ref:`keyed chain <keyed_chain>`, which serializes and de-duplicates an entire chain of tokenizable objects to disk in a single file.
 However, **gufe** provides no tooling for deduplicating across chains stored to disk and it is up to the storage system to implement its own registry for handling this.
 
 The main idea is to use the ``GufeKey`` to ensure uniqueness, and to use it as a label for the object's serialized representation.
 Additionally, the ``GufeKey``, which is simply a string, can be used as a stand-in for the object.
 When an outer ``GufeTokenizable`` contains an inner ``GufeTokenizable``, the outer can store the ``GufeKey`` in place of the inner object.
-That is, we can store by reference to the ``GufeKey``.
+
 
 To convert a ``GufeTokenizable`` ``obj`` into a dictionary that references inner ``GufeTokenizable``\s by ``GufeKey``, use ``obj.to_keyed_dict()``.
 That method replaces each ``GufeTokenizable`` by a ``dict`` with a single key, ``':gufe-key:'``, mapping to the ``GufeKey`` of the object.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
This PR adds information about how you can leverage `to_keyed_chain()` as a way for serializing to disk.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
