### PR TITLE
Update file handling POSIX error

### DIFF
--- a/gufe/vendor/pdb_file/pdbfile.py
+++ b/gufe/vendor/pdb_file/pdbfile.py
@@ -36,6 +36,8 @@ import math
 import os
 import sys
 import xml.etree.ElementTree as etree
+import io
+from pathlib import PosixPath
 from copy import copy
 from datetime import date
 
@@ -99,7 +101,7 @@ class PDBFile:
 
         Parameters
         ----------
-        file : string or file
+        file : str, PosixPath, or file
             the name of the file to load.  Alternatively you can pass an open file object.
         extraParticleIdentifier : string='EP'
             if this value appears in the element column for an ATOM record, the Atom's element will be set to None to mark it as an extra particle
@@ -152,8 +154,8 @@ class PDBFile:
 
         if isinstance(file, PdbStructure):
             pdb = file
-        else:
-            inputfile = file
+        elif isinstance(file, str) or isinstance(file, PosixPath) or isinstance(file, io.StringIO):
+            inputfile = str(file) if isinstance(file, PosixPath) else file 
             own_handle = False
             if isinstance(file, str):
                 inputfile = open(file)
@@ -165,6 +167,8 @@ class PDBFile:
             )
             if own_handle:
                 inputfile.close()
+        else:
+            raise TypeError(f"Expected file types: PdbStructure, str, StringIO, or PosixPath. File, {file}, is type {type(file)}.")
         PDBFile._loadNameReplacementTables()
 
         # Build the topology

--- a/gufe/vendor/pdb_file/pdbfile.py
+++ b/gufe/vendor/pdb_file/pdbfile.py
@@ -155,7 +155,7 @@ class PDBFile:
         if isinstance(file, PdbStructure):
             pdb = file
         elif isinstance(file, str) or isinstance(file, PosixPath) or isinstance(file, io.StringIO):
-            inputfile = str(file) if isinstance(file, PosixPath) else file 
+            inputfile = str(file) if isinstance(file, PosixPath) else file
             own_handle = False
             if isinstance(file, str):
                 inputfile = open(file)


### PR DESCRIPTION
When I pass a POSIX path to:
```python
protein = ProteinComponent.from_pdb_file(protein_path_obj)
```
I get the following error that this PR is meant to resolve, and provide actionable feedback if another type is used:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[22], [line 2](vscode-notebook-cell:?execution_count=22&line=2)
      1 # Load protein
----> [2](vscode-notebook-cell:?execution_count=22&line=2) protein = ProteinComponent.from_pdb_file(system.protein)
      3 print(f"Loaded protein: {protein}")
      4 print(f"  Number of atoms: {protein.to_rdkit().GetNumAtoms()}")

File ~/bin/gufe/gufe/components/proteincomponent.py:178, in ProteinComponent.from_pdb_file(cls, pdb_file, name)
    161 @classmethod
    162 def from_pdb_file(cls, pdb_file: PathLike | TextIO, name: str = ""):
    163     """
    164     Create ``ProteinComponent`` from PDB-formatted file.
    165 
   (...)    176         the deserialized molecule
    177     """
--> [178](https://file+.vscode-resource.vscode-cdn.net/Users/jenniferclark/bin/openfe-benchmarks/examples/~/bin/gufe/gufe/components/proteincomponent.py:178)     openmm_PDBFile = PDBFile(pdb_file)
    179     return cls._from_openmmPDBFile(openmm_PDBFile=openmm_PDBFile, name=name)

File ~/bin/gufe/gufe/vendor/pdb_file/pdbfile.py:161, in PDBFile.__init__(self, file, extraParticleIdentifier)
    159     inputfile = open(file)
    160     own_handle = True
--> [161](https://file+.vscode-resource.vscode-cdn.net/Users/jenniferclark/bin/openfe-benchmarks/examples/~/bin/gufe/gufe/vendor/pdb_file/pdbfile.py:161) pdb = PdbStructure(
    162     inputfile,
    163     load_all_models=True,
    164     extraParticleIdentifier=extraParticleIdentifier,
    165 )
    166 if own_handle:
    167     inputfile.close()

File ~/bin/gufe/gufe/vendor/pdb_file/pdbstructure.py:154, in PdbStructure.__init__(self, input_stream, load_all_models, extraParticleIdentifier)
    152 self.modified_residues = []
    153 # read file
--> [154](https://file+.vscode-resource.vscode-cdn.net/Users/jenniferclark/bin/openfe-benchmarks/examples/~/bin/gufe/gufe/vendor/pdb_file/pdbstructure.py:154) self._load(input_stream)

File ~/bin/gufe/gufe/vendor/pdb_file/pdbstructure.py:160, in PdbStructure._load(self, input_stream)
    158 self._reset_residue_numbers()
    159 # Read one line at a time
--> [160](https://file+.vscode-resource.vscode-cdn.net/Users/jenniferclark/bin/openfe-benchmarks/examples/~/bin/gufe/gufe/vendor/pdb_file/pdbstructure.py:160) for pdb_line in input_stream:
    161     if not isinstance(pdb_line, str):
    162         pdb_line = pdb_line.decode("utf-8")

TypeError: 'PosixPath' object is not iterable
```

Without this change I need to resolve with:
```python
protein = ProteinComponent.from_pdb_file(str(protein_path_obj))
```
Which is kinda clunky 

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.