### PR TITLE
[DNM] add immutability test to mixin

### DIFF
--- a/gufe/tests/test_tokenization.py
+++ b/gufe/tests/test_tokenization.py
@@ -181,6 +181,13 @@ class GufeTokenizableTestsMixin(abc.ABC):
         else:
             assert repr(instance) == self.repr
 
+    def test_immutability(self, instance):
+        keys = instance.to_dict().keys()
+        tmp_instance = instance.copy()
+        for key in keys:
+            with pytest.raises(AttributeError, match=key):
+                setattr(tmp_instance, key, 5)
+
 
 class TestGufeTokenizable(GufeTokenizableTestsMixin):
     cls = Container


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
It's my understanding that gufetokenizables should be immutable, and therefore this test should pass. open to discussion though.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
