### PR TITLE
add deprecation warning for to_rbfe_alchemical_network

### DIFF
--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import warnings
 from collections.abc import Iterable
 from itertools import chain
 
@@ -270,6 +271,10 @@ class LigandNetwork(GufeTokenizable):
             The label for the component undergoing an alchemical transformation
             (default ``'ligand'``).
         """
+        warnings.warn(
+            ("_to_rfe_alchemical_network is deprecated and will be removed in the next minor release of gufe."),
+            DeprecationWarning,
+        )
         transformations = []
         for edge in self.edges:
             for leg_name, labels in leg_labels.items():

--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -271,10 +271,7 @@ class LigandNetwork(GufeTokenizable):
             The label for the component undergoing an alchemical transformation
             (default ``'ligand'``).
         """
-        warnings.warn(
-            ("_to_rfe_alchemical_network is deprecated and will be removed in the next minor release of gufe."),
-            DeprecationWarning,
-        )
+
         transformations = []
         for edge in self.edges:
             for leg_name, labels in leg_labels.items():
@@ -334,6 +331,11 @@ class LigandNetwork(GufeTokenizable):
             Additional non-alchemical components; keyword will be the string
             label for the component.
         """
+
+        warnings.warn(
+            ("to_rbfe_alchemical_network() is deprecated and will be removed in the next minor release of gufe."),
+            DeprecationWarning,
+        )
         components = {"protein": protein, "solvent": solvent, **other_components}
         leg_labels = {
             "solvent": ["ligand", "solvent"],
@@ -346,24 +348,6 @@ class LigandNetwork(GufeTokenizable):
             autoname=autoname,
             autoname_prefix=autoname_prefix,
         )
-
-    # on hold until we figure out how to best hack in the PME/NoCutoff
-    # switch
-    # def to_rhfe_alchemical_network(self, *, solvent, protocol,
-    #                                autoname=True,
-    #                                autoname_prefix="easy_rhfe",
-    #                                **other_components):
-    #     leg_labels = {
-    #         "solvent": ["ligand", "solvent"] + list(other_components),
-    #         "vacuum": ["ligand"] + list(other_components),
-    #     }
-    #     return self._to_rfe_alchemical_network(
-    #         components={"solvent": solvent, **other_components},
-    #         leg_labels=leg_labels,
-    #         protocol=protocol,
-    #         autoname=autoname,
-    #         autoname_prefix=autoname_prefix
-    #     )
 
     def is_connected(self) -> bool:
         """Indicates whether all ligands in the network are (directly or indirectly)

--- a/gufe/tests/test_ligand_network.py
+++ b/gufe/tests/test_ligand_network.py
@@ -394,9 +394,10 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
             others = {}
 
         protocol = DummyProtocol(DummyProtocol.default_settings())
-        rbfe = real_molecules_network.to_rbfe_alchemical_network(
-            solvent=solv_comp, protein=prot_comp, protocol=protocol, **others
-        )
+        with pytest.warns(DeprecationWarning, match="to_rbfe_alchemical_network"):
+            rbfe = real_molecules_network.to_rbfe_alchemical_network(
+                solvent=solv_comp, protein=prot_comp, protocol=protocol, **others
+            )
 
         expected_names = {
             "easy_rbfe_benzene_solvent_toluene_solvent",
@@ -436,25 +437,27 @@ class TestLigandNetwork(GufeTokenizableTestsMixin):
             assert edge.mapping in real_molecules_network.edges
 
     def test_to_rbfe_alchemical_network_autoname_false(self, real_molecules_network, prot_comp, solv_comp):
-        rbfe = real_molecules_network.to_rbfe_alchemical_network(
-            solvent=solv_comp,
-            protein=prot_comp,
-            protocol=DummyProtocol(DummyProtocol.default_settings()),
-            autoname=False,
-        )
+        with pytest.warns(DeprecationWarning, match="to_rbfe_alchemical_network"):
+            rbfe = real_molecules_network.to_rbfe_alchemical_network(
+                solvent=solv_comp,
+                protein=prot_comp,
+                protocol=DummyProtocol(DummyProtocol.default_settings()),
+                autoname=False,
+            )
         for edge in rbfe.edges:
             assert edge.name == ""
             for sys in [edge.stateA, edge.stateB]:
                 assert sys.name == ""
 
     def test_to_rbfe_alchemical_network_autoname_true(self, real_molecules_network, prot_comp, solv_comp):
-        rbfe = real_molecules_network.to_rbfe_alchemical_network(
-            solvent=solv_comp,
-            protein=prot_comp,
-            protocol=DummyProtocol(DummyProtocol.default_settings()),
-            autoname=True,
-            autoname_prefix="",
-        )
+        with pytest.warns(DeprecationWarning, match="to_rbfe_alchemical_network"):
+            rbfe = real_molecules_network.to_rbfe_alchemical_network(
+                solvent=solv_comp,
+                protein=prot_comp,
+                protocol=DummyProtocol(DummyProtocol.default_settings()),
+                autoname=True,
+                autoname_prefix="",
+            )
         expected_names = {
             "benzene_complex_toluene_complex",
             "benzene_solvent_toluene_solvent",

--- a/news/deprecate_to_rbfe_alchemical_network.rst
+++ b/news/deprecate_to_rbfe_alchemical_network.rst
@@ -8,7 +8,7 @@
 
 **Deprecated:**
 
-* ``LigandNetwork.to_rbfe_alchemical_network()`` has been deprecated and will be removed in gufe v1.10.0.
+* ``LigandNetwork.to_rbfe_alchemical_network()`` has been deprecated and will be removed in gufe v1.10.0 (`PR #726 <https://github.com/OpenFreeEnergy/gufe/pull/726>`_).
 
 **Removed:**
 

--- a/news/deprecate_to_rbfe_alchemical_network.rst
+++ b/news/deprecate_to_rbfe_alchemical_network.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* ``LigandNetwork.to_rbfe_alchemical_network()`` has been deprecated and will be removed in gufe v1.10.0.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
resolves https://github.com/OpenFreeEnergy/gufe/issues/654

<!--

Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
