### PR TITLE
deprecate ligand network to_rbfe_alchemical_network in gufe 2.0

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,7 +17,7 @@ v1.8.0
 
 **Deprecated:**
 
-* ``LigandNetwork.to_rbfe_alchemical_network()`` has been deprecated and will be removed in gufe v1.10.0 (`PR #726 <https://github.com/OpenFreeEnergy/gufe/pull/726>`_).
+* ``LigandNetwork.to_rbfe_alchemical_network()`` has been deprecated and will be removed in gufe v2.0 (`PR #726 <https://github.com/OpenFreeEnergy/gufe/pull/726>`_).
 
 **Fixed:**
 

--- a/gufe/ligandnetwork.py
+++ b/gufe/ligandnetwork.py
@@ -333,7 +333,7 @@ class LigandNetwork(GufeTokenizable):
         """
 
         warnings.warn(
-            ("to_rbfe_alchemical_network() is deprecated and will be removed in the next minor release of gufe."),
+            ("to_rbfe_alchemical_network() is deprecated and will be removed in version 2.0."),
             DeprecationWarning,
         )
         components = {"protein": protein, "solvent": solvent, **other_components}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
@mikemhenry made the good point that this shouldn't be removed until 2.0.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
