### PR TITLE
Add empty validate method for Component

### DIFF
--- a/gufe/components/component.py
+++ b/gufe/components/component.py
@@ -28,3 +28,15 @@ class Component(GufeTokenizable):
     def total_charge(self) -> int | None:
         """Net formal charge for the ``Component``, if defined."""
         ...
+
+    def validate(self, **kwargs):
+        """
+        Validate this Component.
+
+        This method may be overridden by subclasses to implement
+        component-specific consistency or sanity checks.
+
+        Implementations should raise an exception if validation fails.
+        The base implementation performs no checks.
+        """
+        pass

--- a/gufe/tests/test_proteincomponent.py
+++ b/gufe/tests/test_proteincomponent.py
@@ -365,6 +365,10 @@ class TestProteinComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComponentM
             with mock.patch("rdkit.Chem.rdchem.PeriodicTable.GetValenceList", return_value=[10000000]):
                 self.cls.from_pdb_file(ALL_PDB_LOADERS["3tzr_rna"]())
 
+    def test_empty_validate(self, instance):
+        """Should pass"""
+        instance.validate()
+
 
 def test_no_monomer_info_error(ethane):
     with pytest.raises(TypeError):

--- a/news/component_validate.rst
+++ b/news/component_validate.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Adds a .validate() method to gufe Components
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
