### PR TITLE
Bump conda-cron CI Python versions

### DIFF
--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
         python-version:
-          - "3.10"  # TODO: bump to 3.11-3.13 after v1.6.0 is released.
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Bump Python version to include 3.13 in CI matrix.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
