### PR TITLE
Add missing files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include gufe/tests/data/ *.cif
 recursive-include gufe/tests/data/ *.mol2
 recursive-include gufe/tests/data/ *.json
 recursive-include gufe/tests/data/ *.graphml
+recursive-include gufe/tests/data/ *.gz


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Since we build on conda-forge with a tarball and not in a git repo, `setuptools_scm` doesn't know what files to include via tracking, and then falls back to default behavior, so we need to include these files in the `MANIFEST.in`. We should investigate if there are other ways to do this.

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
