### PR TITLE
rename protocoldag_cache to protocoldag-results_cache

### DIFF
--- a/gufe/protocols/protocoldag.py
+++ b/gufe/protocols/protocoldag.py
@@ -468,10 +468,10 @@ def execute_DAG(
 
     all_cached_results: list[ProtocolUnitResult] = []  # store all unitresults found in the cache
     if cache_basedir is not None:
-        dag_unitresults_dir = cache_basedir / f"{str(protocoldag.key)}_cache"
-        dag_unitresults_dir.mkdir(exist_ok=True, parents=True)
+        dag_unitresults_cache = cache_basedir / f"{str(protocoldag.key)}-results_cache"
+        dag_unitresults_cache.mkdir(exist_ok=True, parents=True)
 
-        for file in dag_unitresults_dir.rglob("*.json"):
+        for file in dag_unitresults_cache.rglob("*.json"):
             try:
                 unit_result = ProtocolUnitResult.from_json(file)
             except JSONDecodeError as e:
@@ -531,7 +531,7 @@ def execute_DAG(
 
                 # Serialize results if requested
                 if cache_basedir is not None:
-                    result.to_json(dag_unitresults_dir / f"{str(unit.key)}_unitresults.json")
+                    result.to_json(dag_unitresults_cache / f"{str(unit.key)}_unitresults.json")
                 break
             attempt += 1
 
@@ -543,7 +543,7 @@ def execute_DAG(
             shutil.rmtree(shared_path)
 
     if not keep_cache and cache_basedir is not None:
-        shutil.rmtree(dag_unitresults_dir)
+        shutil.rmtree(dag_unitresults_cache)
 
     return ProtocolDAGResult(
         name=protocoldag.name,

--- a/gufe/tests/test_protocoldag.py
+++ b/gufe/tests/test_protocoldag.py
@@ -116,7 +116,7 @@ def test_execute_dag(tmp_path, keep_shared, keep_scratch, keep_cache, writefile_
         shared_file = os.path.join(shared, f"shared_{str(pu.key)}_attempt_0", f"unit_{id}_shared.txt")
         scratch_file = os.path.join(scratch, f"scratch_{str(pu.key)}_attempt_0", f"unit_{id}_scratch.txt")
         unit_result_file = os.path.join(
-            cache_basedir, f"{str(writefile_dag.key)}_cache", f"{str(pu.key)}_unitresults.json"
+            cache_basedir, f"{str(writefile_dag.key)}-results_cache", f"{str(pu.key)}_unitresults.json"
         )
 
         if capture_stderr_stdout:
@@ -206,13 +206,16 @@ def test_execute_DAG_cached_unitresults(tmp_path):
     )
 
     for pu in dep_dag.protocol_units:
-        assert os.path.exists(os.path.join(unit_results_dir, f"{dep_dag.key}_cache", f"{str(pu.key)}_unitresults.json"))
+        assert os.path.exists(
+            os.path.join(unit_results_dir, f"{dep_dag.key}-results_cache", f"{str(pu.key)}_unitresults.json")
+        )
 
     # choose a terminal result so that only one node is rerun
     pu_to_corrupt = dependent_units[0]
 
     with open(
-        os.path.join(unit_results_dir, f"{dep_dag.key}_cache", f"{str(pu_to_corrupt.key)}_unitresults.json"), "a"
+        os.path.join(unit_results_dir, f"{dep_dag.key}-results_cache", f"{str(pu_to_corrupt.key)}_unitresults.json"),
+        "a",
     ) as f:
         f.write("string that will break JSON.")
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
after testing out https://github.com/OpenFreeEnergy/openfe/1848, I think that we should rename this to make it clearer.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
