### PR TITLE
Add ComponentValidationError

### DIFF
--- a/gufe/components/errors.py
+++ b/gufe/components/errors.py
@@ -1,0 +1,6 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/gufe
+
+
+class ComponentValidationError(Exception):
+    """Error when a Component fails validation checks."""

--- a/gufe/components/solvatedpdbcomponent.py
+++ b/gufe/components/solvatedpdbcomponent.py
@@ -16,9 +16,9 @@ from ..vendor.openff.interchange._annotations import _is_box_shape
 from ..vendor.openff.interchange._packmol import _box_vectors_are_in_reduced_form
 from ..vendor.pdb_file.pdbfile import PDBFile
 from ..vendor.pdb_file.pdbxfile import PDBxFile
+from .errors import ComponentValidationError
 from .proteincomponent import ProteinComponent
 from .solventcomponent import BaseSolventComponent
-from .errors import ComponentValidationError
 
 
 class SolvatedPDBComponent(ProteinComponent, BaseSolventComponent):

--- a/gufe/components/solvatedpdbcomponent.py
+++ b/gufe/components/solvatedpdbcomponent.py
@@ -18,6 +18,7 @@ from ..vendor.pdb_file.pdbfile import PDBFile
 from ..vendor.pdb_file.pdbxfile import PDBxFile
 from .proteincomponent import ProteinComponent
 from .solventcomponent import BaseSolventComponent
+from .errors import ComponentValidationError
 
 
 class SolvatedPDBComponent(ProteinComponent, BaseSolventComponent):
@@ -113,9 +114,14 @@ class SolvatedPDBComponent(ProteinComponent, BaseSolventComponent):
         ----------
         min_density : openff.units.Quantity
             Minimum acceptable density. Default: 0.7 g/ml
+
+        Raises
+        ------
+        ComponentValidationError
+            If the density is lower than the minimum density.
         """
         if self.density < min_density:  # type: ignore
-            raise ValueError(
+            raise ComponentValidationError(
                 "Estimated system density is very low.\n  "
                 f"Density: {self.density:.3f} (expected ≥ {min_density}). "
                 "This usually indicates missing solvent or incorrect box vectors."
@@ -453,7 +459,7 @@ class ProteinMembraneComponent(SolvatedPDBComponent):
 
         Raises
         ------
-        ValueError
+        ComponentValidationError
             If one or more validation checks fail. All detected validation
             errors are aggregated and reported together.
         """
@@ -462,7 +468,7 @@ class ProteinMembraneComponent(SolvatedPDBComponent):
         # 1. Density check
         try:
             super().validate(min_density=min_density)
-        except ValueError as e:
+        except ComponentValidationError as e:
             errors.append(str(e))
 
         # 2. Water count check
@@ -470,7 +476,7 @@ class ProteinMembraneComponent(SolvatedPDBComponent):
             errors.append(f"Only {self.n_waters} water molecules detected (expected ≥ {min_waters}).")
 
         if errors:
-            raise ValueError(
+            raise ComponentValidationError(
                 "ProteinMembraneComponent validation failed:\n"
                 + "\n".join(f"- {e}" for e in errors)
                 + "\nThis usually indicates missing solvent or incorrect box vectors."

--- a/gufe/tests/test_solvatedpdbcomponent.py
+++ b/gufe/tests/test_solvatedpdbcomponent.py
@@ -10,6 +10,7 @@ from openff.units import unit as offunit
 from rdkit import Chem
 
 from gufe import ProteinComponent, ProteinMembraneComponent, SolvatedPDBComponent
+from gufe.components.errors import ComponentValidationError
 
 from ..vendor.openff.interchange._annotations import _is_box_shape
 from ..vendor.openff.interchange._packmol import _box_vectors_are_in_reduced_form
@@ -165,7 +166,7 @@ class TestSolvatedPDBComponent(GufeTokenizableTestsMixin, ExplicitMoleculeCompon
         assert instance.density > 500 * offunit.gram / offunit.liter
         instance.box_vectors = instance.box_vectors * 100
         assert instance.density < 500 * offunit.gram / offunit.liter
-        with pytest.raises(ValueError, match="density is very low"):
+        with pytest.raises(ComponentValidationError, match="density is very low"):
             instance.validate(min_density=500 * offunit.gram / offunit.liter)
 
     def test_box_vectors_affect_equality(self, instance):
@@ -296,13 +297,13 @@ class TestProteinMembraneComponent(GufeTokenizableTestsMixin, ExplicitMoleculeCo
         comp = ProteinMembraneComponent.from_pdb_file(PDB_181L_path, infer_box_vectors=True)
         # Only 8 Xray waters, not properly solvated
         assert comp.n_waters == 8
-        with pytest.raises(ValueError, match="water molecules detected"):
+        with pytest.raises(ComponentValidationError, match="water molecules detected"):
             comp.validate(min_waters=50)
 
     def test_validate_few_waters_and_low_density_raises(self, PDB_181L_path):
         comp = ProteinMembraneComponent.from_pdb_file(PDB_181L_path, infer_box_vectors=True)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ComponentValidationError) as excinfo:
             comp.validate()
 
         # Check that both error messages appear

--- a/news/component_errors.rst
+++ b/news/component_errors.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Adds a ComponentValidationError type to be used specifically
+  when Component.validate() fails.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Add an error type to more specifically handle cases when Component validation fails.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
