### PR TITLE
Add lipid17_merged.xml to default FF settings

### DIFF
--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -160,7 +160,7 @@ class OpenMMSystemGeneratorFFSettings(BaseForceFieldSettings):
         "amber/tip3p_standard.xml",  # TIP3P and recommended monovalent ion parameters
         "amber/tip3p_HFE_multivalent.xml",  # for divalent ions
         "amber/phosaa10.xml",  # Handles THE TPO
-        "amber/lipid17_merged.xml", # lipids
+        "amber/lipid17_merged.xml",  # lipids
     ]
     """List of force field paths for all components except :class:`SmallMoleculeComponent` """
 

--- a/gufe/settings/models.py
+++ b/gufe/settings/models.py
@@ -160,6 +160,7 @@ class OpenMMSystemGeneratorFFSettings(BaseForceFieldSettings):
         "amber/tip3p_standard.xml",  # TIP3P and recommended monovalent ion parameters
         "amber/tip3p_HFE_multivalent.xml",  # for divalent ions
         "amber/phosaa10.xml",  # Handles THE TPO
+        "amber/lipid17_merged.xml", # lipids
     ]
     """List of force field paths for all components except :class:`SmallMoleculeComponent` """
 

--- a/gufe/tests/test_models.py
+++ b/gufe/tests/test_models.py
@@ -95,6 +95,7 @@ def test_openmmffsettings_schema():
                     "amber/tip3p_standard.xml",
                     "amber/tip3p_HFE_multivalent.xml",
                     "amber/phosaa10.xml",
+                    "amber/lipid17_merged.xml",
                 ],
                 "items": {"type": "string"},
                 "title": "Forcefields",

--- a/gufe/tests/test_serialization_json.py
+++ b/gufe/tests/test_serialization_json.py
@@ -286,6 +286,7 @@ class TestSettingsCodec(CustomJSONCodingTest):
                         "amber/tip3p_standard.xml",
                         "amber/tip3p_HFE_multivalent.xml",
                         "amber/phosaa10.xml",
+                        "amber/lipid17_merged.xml",
                     ],
                     "small_molecule_forcefield": "openff-2.2.1",
                     "nonbonded_method": "PME",

--- a/gufe/tests/test_transformation.py
+++ b/gufe/tests/test_transformation.py
@@ -35,7 +35,7 @@ def complex_equilibrium(solvated_complex):
 
 class TestTransformation(GufeTokenizableTestsMixin):
     cls = Transformation
-    repr = "Transformation(stateA=ChemicalSystem(name=, components={'ligand': SmallMoleculeComponent(name=toluene), 'solvent': SolventComponent(name=O, K+, Cl-)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-13cfc31d879fd8877e6a57558c2e9f38>, name=None)"
+    repr = "Transformation(stateA=ChemicalSystem(name=, components={'ligand': SmallMoleculeComponent(name=toluene), 'solvent': SolventComponent(name=O, K+, Cl-)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-e74b8a34526e7a7a5541d63e9ef511d5>, name=None)"
 
     @pytest.fixture
     def instance(self, absolute_transformation):
@@ -206,7 +206,7 @@ class TestTransformation(GufeTokenizableTestsMixin):
 
 class TestNonTransformation(GufeTokenizableTestsMixin):
     cls = NonTransformation
-    repr = "NonTransformation(system=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-13cfc31d879fd8877e6a57558c2e9f38>, name=None)"
+    repr = "NonTransformation(system=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-e74b8a34526e7a7a5541d63e9ef511d5>, name=None)"
 
     @pytest.fixture
     def instance(self, complex_equilibrium):

--- a/news/lipids-ff.rst
+++ b/news/lipids-ff.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* `amber/lipid17_merged.xml` is now defined by default in `forcefield` list
+  in :class:`OpenMMSystemGeneratorFFSettings` (PR #767).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
In https://github.com/OpenFreeEnergy/openfe/pull/1561 we found that we had to add lipid17 to all the adaptive settings. @jthorton  brought up the idea of just adding it to our default FF list since it shouldn't clash other FFs being defined.

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
