### PR TITLE
Bump up CI action versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,12 +42,12 @@ jobs:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: "Setup Micromamba"
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-binary-path: ~/.local/bin/micromamba
           environment-file: environment.yml
@@ -77,7 +77,7 @@ jobs:
           micromamba list
 
       - name: Cache Pooch data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             # linux cache location
@@ -109,12 +109,12 @@ jobs:
     name: "package build and install test"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: "Setup Micromamba"
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment.yml
           environment-name: gufe

--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           path: gufe_repo
@@ -63,7 +63,7 @@ jobs:
           init-shell: bash
 
       - name: Cache Pooch data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             # linux cache location

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -19,7 +19,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: "Setup Micromamba"
         uses: mamba-org/setup-micromamba@v2


### PR DESCRIPTION
Just noticed we were running an older version of setup-micromamba, so I bumped everything up that made sense.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [N/A] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
