### PR TITLE
Couple typo fixes found with codespell

### DIFF
--- a/gufe/tests/test_smallmoleculecomponent.py
+++ b/gufe/tests/test_smallmoleculecomponent.py
@@ -235,7 +235,7 @@ class TestSmallMoleculeComponentConversion:
         assert off_ethane.name == "ethane"
 
 
-@pytest.mark.skipif(not HAS_OFFTK, reason="no openff tookit available")
+@pytest.mark.skipif(not HAS_OFFTK, reason="no openff toolkit available")
 class TestSmallMoleculeComponentPartialCharges:
     @pytest.fixture(scope="function")
     def charged_off_ethane(self, named_ethane):

--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -656,7 +656,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         """
         Generate a JSON keyed chain representation.
 
-        This will be writen to the filepath or filelike object if passed.
+        This will be written to the filepath or filelike object if passed.
 
         Parameters
         ----------
@@ -732,7 +732,7 @@ class GufeTokenizable(abc.ABC, metaclass=_ABCGufeClassMeta):
         """
         Generate a MessagePack keyed chain representation.
 
-        This will be writen to the filepath or filelike object if passed.
+        This will be written to the filepath or filelike object if passed.
 
         Parameters
         ----------
@@ -958,7 +958,7 @@ class KeyedChain:
         The ``func`` function is applied to each keyed dict contained
         in the ``KeyedChain``. When it evaluates to a truthy value,
         the ``GufeTokenizable`` is created and yielded. Dependencies
-        of this ``GufeTokenizable`` are derived from preceeding
+        of this ``GufeTokenizable`` are derived from preceding
         portions of the ``KeyedChain``.
 
         Example

--- a/gufe/transformations/transformation.py
+++ b/gufe/transformations/transformation.py
@@ -311,7 +311,7 @@ class NonTransformation(TransformationBase):
     def stateA(self) -> ChemicalSystem:
         """The :class:`.ChemicalSystem` this ``NonTransformation`` samples.
 
-        Synonomous with ``system`` attribute and identical to ``stateB``.
+        Synonymous with ``system`` attribute and identical to ``stateB``.
 
         """
         return self._system
@@ -320,7 +320,7 @@ class NonTransformation(TransformationBase):
     def stateB(self) -> ChemicalSystem:
         """The :class:`.ChemicalSystem` this ``NonTransformation`` samples.
 
-        Synonomous with ``system`` attribute and identical to ``stateA``.
+        Synonymous with ``system`` attribute and identical to ``stateA``.
 
 
         """


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [N/A] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
