### PR TITLE
add ruff formatting to docstrings

### DIFF
--- a/gufe/tokenization.py
+++ b/gufe/tokenization.py
@@ -284,17 +284,17 @@ def nested_key_moved(dct, old_name, new_name):
     labels that match Python namespace/list notations. That is, if ``dct``
     is the following dict::
 
-        {'first': {'inner': ['list', 'of', 'words']}}
+        {"first": {"inner": ["list", "of", "words"]}}
 
     then the label ``'first.inner[1]'`` would refer to the word ``'of'``.
 
     In that case, the following call::
 
-        nested_key_moved(dct, 'first.inner[1]', 'second')
+        nested_key_moved(dct, "first.inner[1]", "second")
 
     would result in the dictionary::
 
-        {'first': {'inner': ['list', 'words']}, 'second': 'of'}
+        {"first": {"inner": ["list", "words"]}, "second": "of"}
 
     This is particular useful for things like protocol settings, which
     present as nested objects like this.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ fallback_version = "0.0.0"
 line-length = 120
 exclude = [ "gufe/vendor/*" ]
 
+format.docstring-code-format = true
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 lint.select = [
   "F", # Pyflakes


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
