### PR TITLE
update deprecation warnings

### DIFF
--- a/news/update_to_rbfe_deprecation.rst
+++ b/news/update_to_rbfe_deprecation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* ``LigandNetwork.to_rbfe_alchemical_network()`` has been deprecated and will be removed in gufe v1.13.0 (`PR #793 <https://github.com/OpenFreeEnergy/gufe/pull/793>`_).
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/gufe/ligandnetwork.py
+++ b/src/gufe/ligandnetwork.py
@@ -338,6 +338,7 @@ class LigandNetwork(GufeTokenizable):
         warnings.warn(
             ("to_rbfe_alchemical_network() is deprecated and will be removed in version 1.13.0."),
             DeprecationWarning,
+            stacklevel=2,
         )
         components = {"protein": protein, "solvent": solvent, **other_components}
         leg_labels = {

--- a/src/gufe/ligandnetwork.py
+++ b/src/gufe/ligandnetwork.py
@@ -318,6 +318,9 @@ class LigandNetwork(GufeTokenizable):
     ) -> gufe.AlchemicalNetwork:
         """Create an :class:`.AlchemicalNetwork` from this :class:`.LigandNetwork`.
 
+        .. version-deprecated:: 1.8.0
+            This function is deprecated and will be removed in version 1.13.0.
+
         Parameters
         ----------
         protocol: Protocol
@@ -333,7 +336,7 @@ class LigandNetwork(GufeTokenizable):
         """
 
         warnings.warn(
-            ("to_rbfe_alchemical_network() is deprecated and will be removed in version 2.0."),
+            ("to_rbfe_alchemical_network() is deprecated and will be removed in version 1.13.0."),
             DeprecationWarning,
         )
         components = {"protein": protein, "solvent": solvent, **other_components}

--- a/src/gufe/protocols/protocol.py
+++ b/src/gufe/protocols/protocol.py
@@ -254,6 +254,7 @@ class Protocol(GufeTokenizable):
             warnings.warn(
                 ("mapping input as a dict is deprecated, instead use either a single Mapping or list"),
                 DeprecationWarning,
+                stacklevel=2,
             )
             mapping = list(mapping.values())
 
@@ -364,6 +365,7 @@ class Protocol(GufeTokenizable):
             warnings.warn(
                 "mapping input as a dict is deprecated, instead use either a single Mapping or list",
                 DeprecationWarning,
+                stacklevel=2,
             )
             mapping = list(mapping.values())
 

--- a/src/gufe/tests/test_transformation.py
+++ b/src/gufe/tests/test_transformation.py
@@ -187,10 +187,10 @@ class TestTransformation(GufeTokenizableTestsMixin):
 
     def test_dump_load_roundtrip(self, absolute_transformation):
         string = io.StringIO()
-        with pytest.warns(DeprecationWarning, match="use `to_json()`"):
+        with pytest.warns(DeprecationWarning, match="to_json"):
             absolute_transformation.dump(string)
         string.seek(0)
-        with pytest.warns(DeprecationWarning, match="use `from_json()`"):
+        with pytest.warns(DeprecationWarning, match="from_json"):
             recreated = Transformation.load(string)
         assert absolute_transformation == recreated
 

--- a/src/gufe/tests/test_transformation.py
+++ b/src/gufe/tests/test_transformation.py
@@ -187,10 +187,10 @@ class TestTransformation(GufeTokenizableTestsMixin):
 
     def test_dump_load_roundtrip(self, absolute_transformation):
         string = io.StringIO()
-        with pytest.warns(DeprecationWarning, match="use of this method is deprecated; instead use `to_json`"):
+        with pytest.warns(DeprecationWarning, match="use `to_json()`"):
             absolute_transformation.dump(string)
         string.seek(0)
-        with pytest.warns(DeprecationWarning, match="use of this method is deprecated; instead use `from_json`"):
+        with pytest.warns(DeprecationWarning, match="use `from_json()`"):
             recreated = Transformation.load(string)
         assert absolute_transformation == recreated
 

--- a/src/gufe/transformations/transformation.py
+++ b/src/gufe/transformations/transformation.py
@@ -123,13 +123,16 @@ class TransformationBase(GufeTokenizable):
         which is used in both ``ChemicalSystem`` objects will be represented
         twice in the JSON output.
 
+        version-deprecated :: 1.3.0
+            `.dump()` is deprecated. Use `.to_json() instead`.
+
         Parameters
         ----------
         file : Union[PathLike, FileLike]
             A pathlike of filelike to save this transformation to.
         """
         warnings.warn(
-            ("use of this method is deprecated; instead use `to_json`"),
+            ("`.dump()` is deprecated as of gufe v1.3.0; Use `.to_json()` instead."),
             DeprecationWarning,
         )
         with ensure_filelike(file, mode="w") as f:
@@ -139,13 +142,16 @@ class TransformationBase(GufeTokenizable):
     def load(cls, file):
         """Create a Transformation from a JSON file.
 
+        version-deprecated :: 1.3.0
+            `.load()` is deprecated. Use `.from_json() instead`.
+
         Parameters
         ----------
         file : Union[PathLike, FileLike]
             A pathlike or filelike to read this transformation from.
         """
         warnings.warn(
-            ("use of this method is deprecated; instead use `from_json`"),
+            ("`.load()` is deprecated as of gufe v1.3.0; Use `.from_json()` instead."),
             DeprecationWarning,
         )
         with ensure_filelike(file, mode="r") as f:

--- a/src/gufe/transformations/transformation.py
+++ b/src/gufe/transformations/transformation.py
@@ -134,6 +134,7 @@ class TransformationBase(GufeTokenizable):
         warnings.warn(
             ("`.dump()` is deprecated as of gufe v1.3.0; Use `.to_json()` instead."),
             DeprecationWarning,
+            stacklevel=2,
         )
         with ensure_filelike(file, mode="w") as f:
             json.dump(self.to_dict(), f, cls=JSON_HANDLER.encoder, sort_keys=True)
@@ -153,6 +154,7 @@ class TransformationBase(GufeTokenizable):
         warnings.warn(
             ("`.load()` is deprecated as of gufe v1.3.0; Use `.from_json()` instead."),
             DeprecationWarning,
+            stacklevel=2,
         )
         with ensure_filelike(file, mode="r") as f:
             dct = json.load(f, cls=JSON_HANDLER.decoder)
@@ -214,6 +216,7 @@ class Transformation(TransformationBase):
             warnings.warn(
                 ("mapping input as a dict is deprecated; instead use either a single Mapping or list"),
                 DeprecationWarning,
+                stacklevel=2,
             )
             mapping = list(mapping.values())
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Updating `to_rbfe_alchemical_network` deprecation timeline from v2.0 to next minor release.

Also including lessons learned from:
https://github.com/OpenFreeEnergy/konnektor/pull/250
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
