### PR TITLE
transformations - use parent class init

### DIFF
--- a/src/gufe/transformations/transformation.py
+++ b/src/gufe/transformations/transformation.py
@@ -213,10 +213,9 @@ class Transformation(TransformationBase):
 
         self._stateA = stateA
         self._stateB = stateB
-        self._protocol = protocol
         self._mapping = mapping
-        self._name = name
-        self._metadata = metadata or {}
+
+        super().__init__(protocol=protocol, name=name, metadata=metadata)
 
         if validate:
             self.protocol.validate(
@@ -313,9 +312,7 @@ class NonTransformation(TransformationBase):
         """
 
         self._system = system
-        self._protocol = protocol
-        self._name = name
-        self._metadata = metadata or {}
+        super().__init__(protocol=protocol, name=name, metadata=metadata)
 
         if validate:
             self.protocol.validate(

--- a/src/gufe/transformations/transformation.py
+++ b/src/gufe/transformations/transformation.py
@@ -204,6 +204,8 @@ class Transformation(TransformationBase):
         :meth:`.Protocol.validate`
 
         """
+        super().__init__(protocol=protocol, name=name, metadata=metadata)
+
         if isinstance(mapping, dict):
             warnings.warn(
                 ("mapping input as a dict is deprecated; instead use either a single Mapping or list"),
@@ -214,8 +216,6 @@ class Transformation(TransformationBase):
         self._stateA = stateA
         self._stateB = stateB
         self._mapping = mapping
-
-        super().__init__(protocol=protocol, name=name, metadata=metadata)
 
         if validate:
             self.protocol.validate(
@@ -310,9 +310,9 @@ class NonTransformation(TransformationBase):
             Whether or not to validate the inputs to be provided to
             the :class:`.Protocol`.
         """
+        super().__init__(protocol=protocol, name=name, metadata=metadata)
 
         self._system = system
-        super().__init__(protocol=protocol, name=name, metadata=metadata)
 
         if validate:
             self.protocol.validate(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I noticed missing codecov [here](https://app.codecov.io/gh/OpenFreeEnergy/gufe/pull/789?dropdown=coverage&src=pr&el=h1&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term=OpenFreeEnergy). Initializing using the parent class will cover this, and avoid strange diverging behavior in the future.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
