### PR TITLE
turn off api break check (for now)

### DIFF
--- a/.github/workflows/check_for_api_break.yaml
+++ b/.github/workflows/check_for_api_break.yaml
@@ -1,8 +1,7 @@
 name: Check for API breaks
 
 on:
-  pull_request_target:
-    branches:
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

We're having some false positives from the runners failing, I'd like to turn this check off until we address it.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
