### PR TITLE
version-deprecated -> deprecated

### DIFF
--- a/src/gufe/ligandnetwork.py
+++ b/src/gufe/ligandnetwork.py
@@ -318,7 +318,7 @@ class LigandNetwork(GufeTokenizable):
     ) -> gufe.AlchemicalNetwork:
         """Create an :class:`.AlchemicalNetwork` from this :class:`.LigandNetwork`.
 
-        .. version-deprecated:: 1.8.0
+        .. deprecated:: 1.8.0
             This function is deprecated and will be removed in version 1.13.0.
 
         Parameters


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
openfe docs are stuck on sphinx v7.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
