### PR TITLE
make protocol mapping None by default

### DIFF
--- a/news/protocol_mapping_none.rst
+++ b/news/protocol_mapping_none.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Protocols no longer require ``mapping`` as an argument, by default ``mapping=None`` (`PR #809 <https://github.com/OpenFreeEnergy/gufe/pull/809/>`_).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/gufe/protocols/protocol.py
+++ b/src/gufe/protocols/protocol.py
@@ -207,7 +207,7 @@ class Protocol(GufeTokenizable):
         *,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: ComponentMapping | list[ComponentMapping] | dict[str, ComponentMapping] | None,
+        mapping: ComponentMapping | list[ComponentMapping] | dict[str, ComponentMapping] | None = None,
         extends: ProtocolDAGResult | None = None,
         name: str | None = None,
         transformation_key: GufeKey | None = None,
@@ -300,7 +300,7 @@ class Protocol(GufeTokenizable):
         *,
         stateA: ChemicalSystem,
         stateB: ChemicalSystem,
-        mapping: ComponentMapping | list[ComponentMapping] | None,
+        mapping: ComponentMapping | list[ComponentMapping] | None = None,
         extends: ProtocolDAGResult | None = None,
     ):
         r"""Method to override in custom :class:`Protocol` subclasses.

--- a/src/gufe/tests/test_protocol.py
+++ b/src/gufe/tests/test_protocol.py
@@ -218,7 +218,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
             stateA=solvated_ligand,
             stateB=vacuum_ligand,
             name="a dummy run",
-            mapping=None,
         )
 
         shared = pathlib.Path(tmp_path / "shared")
@@ -246,7 +245,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
             stateA=solvated_ligand,
             stateB=vacuum_ligand,
             name="a broken dummy run",
-            mapping=None,
         )
         shared = pathlib.Path(tmp_path / "shared")
         shared.mkdir(parents=True)
@@ -388,7 +386,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
             stateA=solvated_ligand,
             stateB=vacuum_ligand,
             name="a broken dummy run",
-            mapping=None,
         )
         shared = pathlib.Path(tmp_path / "shared")
         shared.mkdir(parents=True)
@@ -575,7 +572,6 @@ class TestProtocol(GufeTokenizableTestsMixin):
                 settings={},
                 stateA=vacuum_ligand,
                 stateB=solvated_ligand,
-                mapping=None,
                 start=None,
                 some_dict={"a": 2, "b": 12},
             )
@@ -645,7 +641,6 @@ class TestNoDepProtocol:
         return protocol.create(
             stateA=ChemicalSystem(components={"solvent": gufe.SolventComponent(positive_ion="Na")}),
             stateB=ChemicalSystem(components={"solvent": gufe.SolventComponent(positive_ion="Li")}),
-            mapping=None,
         )
 
     def test_create(self, dag):
@@ -801,7 +796,6 @@ def test_execute_DAG_retries(solvated_ligand, vacuum_ligand, tmp_path):
     dag = protocol.create(
         stateA=solvated_ligand,
         stateB=vacuum_ligand,
-        mapping=None,
     )
 
     shared = pathlib.Path(tmp_path / "shared")
@@ -837,7 +831,6 @@ def test_execute_DAG_bad_nretries(solvated_ligand, vacuum_ligand, tmp_path):
     dag = protocol.create(
         stateA=solvated_ligand,
         stateB=vacuum_ligand,
-        mapping=None,
     )
 
     shared = pathlib.Path(tmp_path / "shared")


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
If yes, please provide details here:

## Checklist
* [ ] Added a ``news`` entry
* [ ] Filled in the AI-generated code disclosure.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
