### PR TITLE
Allow storing and retrieving of PDBResidueInfo in `to_dict` and `from_dict` for smcs

### DIFF
--- a/news/smc_residue_info.rst
+++ b/news/smc_residue_info.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* ``SmallMoleculeComponent`` serialization now preserves per-atom PDB residue
+  information (residue name, number and chain ID) across
+  ``to_dict``/``from_dict``. Residue names set on a component are retained
+  through round-tripping (PR #811).
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/gufe/components/smallmoleculecomponent.py
+++ b/src/gufe/components/smallmoleculecomponent.py
@@ -265,7 +265,7 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
         output["molprops"] = self._rdkit.GetPropsAsDict(includePrivate=False)
 
         # Store PDBResidueInfo
-        residue_info = []
+        residue_info: list[dict] = []
         for atom in self._rdkit.GetAtoms():
             info = atom.GetPDBResidueInfo()
             if info is None:

--- a/src/gufe/components/smallmoleculecomponent.py
+++ b/src/gufe/components/smallmoleculecomponent.py
@@ -264,7 +264,7 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
 
         output["molprops"] = self._rdkit.GetPropsAsDict(includePrivate=False)
 
-        # Store PDBResidueInfo if at least one atom has it
+        # Store PDBResidueInfo
         residue_info = []
         for atom in self._rdkit.GetAtoms():
             info = atom.GetPDBResidueInfo()
@@ -278,8 +278,8 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
                         "chain_id": info.GetChainId(),
                     }
                 )
-        if any(ri is not None for ri in residue_info):
-            output["residue_info"] = residue_info
+
+        output["residue_info"] = residue_info
 
         return output
 
@@ -319,17 +319,16 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
             b.SetStereo(_INT_TO_BONDSTEREO[bond[3]])
             _setprops(b, bond[4])
 
-        # Restore PDBResidueInfo if present.
+        # Restore PDBResidueInfo
         residue_info = d.get("residue_info")
-        if residue_info is not None:
-            for atom, ri in zip(m.GetAtoms(), residue_info):
-                if ri is None:
-                    continue
-                info = Chem.AtomPDBResidueInfo()
-                info.SetResidueName(ri["residue_name"])
-                info.SetResidueNumber(ri["residue_number"])
-                info.SetChainId(ri["chain_id"])
-                atom.SetPDBResidueInfo(info)
+        for atom, ri in zip(m.GetAtoms(), residue_info):
+            if ri is None:
+                continue
+            info = Chem.AtomPDBResidueInfo()
+            info.SetResidueName(ri["residue_name"])
+            info.SetResidueNumber(ri["residue_number"])
+            info.SetChainId(ri["chain_id"])
+            atom.SetPDBResidueInfo(info)
 
         pos = deserialize_numpy(d["conformer"][0])
         c = Chem.Conformer(m.GetNumAtoms())

--- a/src/gufe/components/smallmoleculecomponent.py
+++ b/src/gufe/components/smallmoleculecomponent.py
@@ -279,7 +279,8 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
                     }
                 )
 
-        output["residue_info"] = residue_info
+        if any(ri is not None for ri in residue_info):
+            output["residue_info"] = residue_info
 
         return output
 
@@ -321,14 +322,15 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
 
         # Restore PDBResidueInfo
         residue_info = d.get("residue_info")
-        for atom, ri in zip(m.GetAtoms(), residue_info):
-            if ri is None:
-                continue
-            info = Chem.AtomPDBResidueInfo()
-            info.SetResidueName(ri["residue_name"])
-            info.SetResidueNumber(ri["residue_number"])
-            info.SetChainId(ri["chain_id"])
-            atom.SetPDBResidueInfo(info)
+        if residue_info is not None:
+            for atom, ri in zip(m.GetAtoms(), residue_info):
+                if ri is None:
+                    continue
+                info = Chem.AtomPDBResidueInfo()
+                info.SetResidueName(ri["residue_name"])
+                info.SetResidueNumber(ri["residue_number"])
+                info.SetChainId(ri["chain_id"])
+                atom.SetPDBResidueInfo(info)
 
         pos = deserialize_numpy(d["conformer"][0])
         c = Chem.Conformer(m.GetNumAtoms())

--- a/src/gufe/components/smallmoleculecomponent.py
+++ b/src/gufe/components/smallmoleculecomponent.py
@@ -265,7 +265,7 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
         output["molprops"] = self._rdkit.GetPropsAsDict(includePrivate=False)
 
         # Store PDBResidueInfo
-        residue_info: list[dict] = []
+        residue_info: list[dict | None] = []
         for atom in self._rdkit.GetAtoms():
             info = atom.GetPDBResidueInfo()
             if info is None:

--- a/src/gufe/components/smallmoleculecomponent.py
+++ b/src/gufe/components/smallmoleculecomponent.py
@@ -264,6 +264,23 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
 
         output["molprops"] = self._rdkit.GetPropsAsDict(includePrivate=False)
 
+        # Store PDBResidueInfo if at least one atom has it
+        residue_info = []
+        for atom in self._rdkit.GetAtoms():
+            info = atom.GetPDBResidueInfo()
+            if info is None:
+                residue_info.append(None)
+            else:
+                residue_info.append(
+                    {
+                        "residue_name": info.GetResidueName(),
+                        "residue_number": info.GetResidueNumber(),
+                        "chain_id": info.GetChainId(),
+                    }
+                )
+        if any(ri is not None for ri in residue_info):
+            output["residue_info"] = residue_info
+
         return output
 
     @classmethod
@@ -301,6 +318,18 @@ class SmallMoleculeComponent(ExplicitMoleculeComponent):
         for bond, b in zip(d["bonds"], m.GetBonds()):
             b.SetStereo(_INT_TO_BONDSTEREO[bond[3]])
             _setprops(b, bond[4])
+
+        # Restore PDBResidueInfo if present.
+        residue_info = d.get("residue_info")
+        if residue_info is not None:
+            for atom, ri in zip(m.GetAtoms(), residue_info):
+                if ri is None:
+                    continue
+                info = Chem.AtomPDBResidueInfo()
+                info.SetResidueName(ri["residue_name"])
+                info.SetResidueNumber(ri["residue_number"])
+                info.SetChainId(ri["chain_id"])
+                atom.SetPDBResidueInfo(info)
 
         pos = deserialize_numpy(d["conformer"][0])
         c = Chem.Conformer(m.GetNumAtoms())

--- a/src/gufe/tests/test_smallmoleculecomponent.py
+++ b/src/gufe/tests/test_smallmoleculecomponent.py
@@ -221,6 +221,20 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComp
         else:
             assert new.smiles == "CC"
 
+    def test_residue_info_roundtrips(self):
+        off = Molecule.from_smiles("CCO")
+        off.generate_conformers(n_conformers=1)
+        for a in off.atoms:
+            a.metadata["residue_name"] = "LIG"
+            a.metadata["chain_id"] = "A"
+        smc = SmallMoleculeComponent.from_openff(off)
+
+        smc_from_dict = SmallMoleculeComponent._from_dict(smc._to_dict())
+        info = smc_from_dict.to_rdkit().GetAtomWithIdx(0).GetPDBResidueInfo()
+        assert info is not None
+        assert info.GetResidueName().strip() == "LIG"
+        assert info.GetChainId().strip() == "A"
+
 
 @pytest.mark.skipif(not HAS_OFFTK, reason="no openff toolkit available")
 class TestSmallMoleculeComponentConversion:

--- a/src/gufe/tests/test_smallmoleculecomponent.py
+++ b/src/gufe/tests/test_smallmoleculecomponent.py
@@ -224,16 +224,26 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComp
     def test_residue_info_roundtrips(self):
         off = openff.toolkit.topology.Molecule.from_smiles("CCO")
         off.generate_conformers(n_conformers=1)
+
+        smc_no_res_info = SmallMoleculeComponent.from_openff(off)
+        assert "residue_info" not in smc_no_res_info._to_dict()
+
+        # Add some residue info
         for a in off.atoms:
             a.metadata["residue_name"] = "LIG"
             a.metadata["chain_id"] = "A"
+
         smc = SmallMoleculeComponent.from_openff(off)
 
-        smc_from_dict = SmallMoleculeComponent._from_dict(smc._to_dict())
-        info = smc_from_dict.to_rdkit().GetAtomWithIdx(0).GetPDBResidueInfo()
-        assert info is not None
-        assert info.GetResidueName().strip() == "LIG"
-        assert info.GetChainId().strip() == "A"
+        # Check that residue info is now stored correctly
+        d = smc._to_dict()
+        assert "residue_info" in d
+        assert d["residue_info"][0]["residue_name"].strip() == "LIG"
+        assert d["residue_info"][0]["chain_id"].strip() == "A"
+
+        # Make sure the residue info round-trips correctly
+        smc_from_dict = SmallMoleculeComponent._from_dict(d)
+        assert smc_from_dict._to_dict()["residue_info"] == d["residue_info"]
 
 
 @pytest.mark.skipif(not HAS_OFFTK, reason="no openff toolkit available")

--- a/src/gufe/tests/test_smallmoleculecomponent.py
+++ b/src/gufe/tests/test_smallmoleculecomponent.py
@@ -228,10 +228,9 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComp
         smc_no_res_info = SmallMoleculeComponent.from_openff(off)
         assert "residue_info" not in smc_no_res_info._to_dict()
 
-        # Add some residue info
-        for a in off.atoms:
-            a.metadata["residue_name"] = "LIG"
-            a.metadata["chain_id"] = "A"
+        # Add residue info only on first atm, so residue_info has both dict and None
+        off.atoms[0].metadata["residue_name"] = "LIG"
+        off.atoms[0].metadata["chain_id"] = "A"
 
         smc = SmallMoleculeComponent.from_openff(off)
 
@@ -240,6 +239,7 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComp
         assert "residue_info" in d
         assert d["residue_info"][0]["residue_name"].strip() == "LIG"
         assert d["residue_info"][0]["chain_id"].strip() == "A"
+        assert d["residue_info"][1] is None
 
         # Make sure the residue info round-trips correctly
         smc_from_dict = SmallMoleculeComponent._from_dict(d)

--- a/src/gufe/tests/test_smallmoleculecomponent.py
+++ b/src/gufe/tests/test_smallmoleculecomponent.py
@@ -222,7 +222,7 @@ class TestSmallMoleculeComponent(GufeTokenizableTestsMixin, ExplicitMoleculeComp
             assert new.smiles == "CC"
 
     def test_residue_info_roundtrips(self):
-        off = Molecule.from_smiles("CCO")
+        off = openff.toolkit.topology.Molecule.from_smiles("CCO")
         off.generate_conformers(n_conformers=1)
         for a in off.atoms:
             a.metadata["residue_name"] = "LIG"


### PR DESCRIPTION


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
If yes, please provide details here:

## Checklist
* [x] Added a ``news`` entry
* [ ] Filled in the AI-generated code disclosure.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
