### PR TITLE
Test/stricter units codec test

### DIFF
--- a/src/gufe/tests/test_serialization_json.py
+++ b/src/gufe/tests/test_serialization_json.py
@@ -253,9 +253,12 @@ class TestSettingsCodec(CustomJSONCodingTest):
             OPENFF_QUANTITY_CODEC,
             OPENFF_UNIT_CODEC,
         ]
-        self.objs = [
-            models.Settings.get_defaults(),
-        ]
+
+        # explicitly set nonbonded_cutoff to *not* be the default,
+        # but keep it coupled so this test fails if defaults change
+        settings = models.Settings.get_defaults()
+        settings.forcefield_settings.nonbonded_cutoff *= 2
+        self.objs = [settings]
         self.dcts = [
             {
                 "__class__": "Settings",
@@ -289,10 +292,10 @@ class TestSettingsCodec(CustomJSONCodingTest):
                     "small_molecule_forcefield": "openff-2.2.1",
                     "nonbonded_method": "PME",
                     "nonbonded_cutoff": {
-                        ":is_custom:": True,
-                        "magnitude": 0.9,
-                        "pint_unit_registry": "openff_units",
+                        "magnitude": 1.8,
                         "unit": "nanometer",
+                        ":is_custom:": True,
+                        "pint_unit_registry": "openff_units",
                     },
                 },
                 "thermo_settings": {
@@ -300,10 +303,10 @@ class TestSettingsCodec(CustomJSONCodingTest):
                     "__module__": "gufe.settings.models",
                     ":is_custom:": True,
                     "temperature": {
-                        ":is_custom:": True,
-                        "magnitude": 300.0,
-                        "pint_unit_registry": "openff_units",
+                        "magnitude": 300,
                         "unit": "kelvin",
+                        ":is_custom:": True,
+                        "pint_unit_registry": "openff_units",
                     },
                     "pressure": None,
                     "ph": None,

--- a/src/gufe/tests/test_serialization_json.py
+++ b/src/gufe/tests/test_serialization_json.py
@@ -292,10 +292,10 @@ class TestSettingsCodec(CustomJSONCodingTest):
                     "small_molecule_forcefield": "openff-2.2.1",
                     "nonbonded_method": "PME",
                     "nonbonded_cutoff": {
-                        "magnitude": 1.8,
-                        "unit": "nanometer",
                         ":is_custom:": True,
+                        "magnitude": 1.8,
                         "pint_unit_registry": "openff_units",
+                        "unit": "nanometer",
                     },
                 },
                 "thermo_settings": {
@@ -303,10 +303,10 @@ class TestSettingsCodec(CustomJSONCodingTest):
                     "__module__": "gufe.settings.models",
                     ":is_custom:": True,
                     "temperature": {
-                        "magnitude": 300.0,
-                        "unit": "kelvin",
                         ":is_custom:": True,
+                        "magnitude": 300.0,
                         "pint_unit_registry": "openff_units",
+                        "unit": "kelvin",
                     },
                     "pressure": None,
                     "ph": None,

--- a/src/gufe/tests/test_serialization_json.py
+++ b/src/gufe/tests/test_serialization_json.py
@@ -303,7 +303,7 @@ class TestSettingsCodec(CustomJSONCodingTest):
                     "__module__": "gufe.settings.models",
                     ":is_custom:": True,
                     "temperature": {
-                        "magnitude": 300,
+                        "magnitude": 300.0,
                         "unit": "kelvin",
                         ":is_custom:": True,
                         "pint_unit_registry": "openff_units",


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

downstream of https://github.com/OpenFreeEnergy/openfe/pull/2058

I _think_ this should address the default-overriding concern seen by @mattwthompson [here](https://github.com/openforcefield/openff-interchange/pull/1501#issuecomment-4545442911) - please correct me if I'm misunderstanding what you ran into.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution:  no
If yes, please provide details here:

## Checklist
* [ ] Added a ``news`` entry
* [ ] Filled in the AI-generated code disclosure.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
