### PR TITLE
[DNM] add py.typed

### DIFF
--- a/src/gufe/tests/test_models.py
+++ b/src/gufe/tests/test_models.py
@@ -6,8 +6,6 @@ json round trip, and physical unit testing belongs here.
 
 from __future__ import annotations
 
-import json
-
 import numpy as np
 import pytest
 from openff.units import Quantity, unit
@@ -124,11 +122,40 @@ def test_openmmffsettings_schema():
     assert val_schema == expected_schema
 
 
-def test_default_settings():
+@pytest.fixture
+def expected_model_dump():
+    model_dump = {
+        "forcefield_settings": {
+            "constraints": "hbonds",
+            "rigid_water": True,
+            "hydrogen_mass": 3.0,
+            "forcefields": [
+                "amber/ff14SB.xml",
+                "amber/tip3p_standard.xml",
+                "amber/tip3p_HFE_multivalent.xml",
+                "amber/phosaa10.xml",
+                "amber/lipid17_merged.xml",
+            ],
+            "small_molecule_forcefield": "openff-2.2.1",
+            "nonbonded_method": "PME",
+            "nonbonded_cutoff": {"val": 1.1, "unit": "nanometer"},
+        },
+        "thermo_settings": {
+            "temperature": {"val": 298, "unit": "kelvin"},
+            "pressure": None,
+            "ph": None,
+            "redox_potential": None,
+        },
+    }
+    return model_dump
+
+
+def test_default_settings(expected_model_dump):
     my_settings = Settings.get_defaults()
     my_settings.thermo_settings.temperature = 298 * unit.kelvin
-    my_settings.model_dump_json()
-    json.dumps(my_settings.model_json_schema(mode="serialization"), indent=2)
+    my_settings.forcefield_settings.nonbonded_cutoff = 1.1 * unit.nanometer
+    model_dump = my_settings.model_dump()
+    assert model_dump == expected_model_dump
 
 
 class TestSettingsValidation:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

This should fix typing headaches seen elsewhere in the ecosystem downstream of gufe, where gufe objects are treated as `Any`.

Don't merge this in until _after_ we [update typing in openfe ](https://github.com/OpenFreeEnergy/openfe/pull/2126)(using this branch to stress-test).

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution:  no


## Checklist
* [ ] Added a ``news`` entry
* [x] Filled in the AI-generated code disclosure.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
