### PR TITLE
make file storage create directory upon instantiation

### DIFF
--- a/news/filestorage.rst
+++ b/news/filestorage.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``FileStorage`` objects now create ``root_dir`` upon initialization by default. To replicate previous behavior, pass ``exists_okay=True`` (`PR #827 <https://github.com/OpenFreeEnergy/gufe/pull/827>`_).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/gufe/storage/externalresource/filestorage.py
+++ b/src/gufe/storage/externalresource/filestorage.py
@@ -15,11 +15,11 @@ class FileStorage(ExternalStorage):
         Parameters
         ----------
         root_dir : pathlib.Path | str
-            directory at which to create the file store.
+            Directory at which to create the file store.
         exist_ok : bool, optional
             If False, requires that `root_dir` not exist, by default False
         """
-        self.root_dir = pathlib.Path(root_dir)
+        self.root_dir = pathlib.Path(root_dir).resolve()
         self.root_dir.mkdir(exist_ok=exist_ok)
 
     def _exists(self, location):

--- a/src/gufe/storage/externalresource/filestorage.py
+++ b/src/gufe/storage/externalresource/filestorage.py
@@ -8,10 +8,19 @@ from ..errors import MissingExternalResourceError
 from .base import ExternalStorage
 
 
-# TODO: this should use pydantic to check init inputs
 class FileStorage(ExternalStorage):
-    def __init__(self, root_dir: pathlib.Path | str):
+    def __init__(self, root_dir: pathlib.Path | str, exist_ok=False):
+        """File-system based ExternalStorage
+
+        Parameters
+        ----------
+        root_dir : pathlib.Path | str
+            directory at which to create the file store.
+        exist_ok : bool, optional
+            If False, requires that `root_dir` not exist, by default False
+        """
         self.root_dir = pathlib.Path(root_dir)
+        self.root_dir.mkdir(exist_ok=exist_ok)
 
     def _exists(self, location):
         return self._as_path(location).exists()

--- a/src/gufe/tests/storage/test_externalresource.py
+++ b/src/gufe/tests/storage/test_externalresource.py
@@ -129,6 +129,19 @@ class TestFileStorage:
         assert set(storage) == expected
         assert set(storage) == set(storage.iter_contents())
 
+    def test_exist_ok(self, tmp_path):
+        store_dir = tmp_path / "store_dir"
+
+        _ = FileStorage(store_dir, exist_ok=False)
+        assert store_dir.is_dir()
+
+        file_store = FileStorage(store_dir, exist_ok=True)
+        assert file_store.root_dir == store_dir
+
+        with pytest.raises(FileExistsError, match=str(store_dir)):
+            # default exist_ok=False
+            file_store = FileStorage(store_dir)
+
     def test_delete_error_not_existing(self, file_storage):
         with pytest.raises(MissingExternalResourceError, match="does not exist"):
             file_storage.delete("baz.txt")

--- a/src/gufe/tests/storage/test_externalresource.py
+++ b/src/gufe/tests/storage/test_externalresource.py
@@ -23,7 +23,8 @@ def file_storage(tmp_path):
     with open(inner_dir / "directory.txt", "wb") as with_dir:
         with_dir.write(b"in a directory")
 
-    return FileStorage(tmp_path)
+    # TODO: why are we manually writing these files instead of using the methods?
+    return FileStorage(tmp_path, exist_ok=True)
 
 
 class TestFileStorage:
@@ -68,9 +69,9 @@ class TestFileStorage:
             assert as_bytes == f.read()
 
     def test_eq(self, tmp_path):
-        reference = FileStorage(tmp_path)
-        assert reference == FileStorage(tmp_path)
-        assert reference != FileStorage(tmp_path / "foo")
+        reference = FileStorage(tmp_path / "foo")
+        assert reference == FileStorage(tmp_path / "foo", exist_ok=True)
+        assert reference != FileStorage(tmp_path / "foo" / "bar")
         assert reference != MemoryStorage()
 
     def test_delete(self, file_storage):
@@ -103,7 +104,7 @@ class TestFileStorage:
             with open(path, "wb") as f:
                 f.write(b"")
 
-        storage = FileStorage(tmp_path)
+        storage = FileStorage(tmp_path, exist_ok=True)
 
         assert set(storage.iter_contents(prefix)) == expected
 
@@ -121,7 +122,7 @@ class TestFileStorage:
             with open(path, "wb") as f:
                 f.write(b"")
 
-        storage = FileStorage(tmp_path)
+        storage = FileStorage(tmp_path, exist_ok=True)
         # We do this to ensure that the expected and the base iter_contents
         # stay together.
         # This should help check if we break the underlying API


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Makes FileStorage behave more similarly to expected Pathlib behavior.
This also enables better error handling and guardrails for  FileSystemWarehouse, as mentioned in https://github.com/OpenFreeEnergy/openfe/pull/2155#issuecomment-5297327437.

As written, this PR breaks existing behavior. Setting `exist_ok=True` by default would keep existing behavior. In my opinion, since ExternalStorage isnt used elsewhere yet, we should stick with the safer `exist_ok=False` option, but I can be convinced otherwise.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
** LLM / AI generated code disclosure **
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no
If yes, please provide details here:

## Checklist
* [x] Added a ``news`` entry
* [x] Filled in the AI-generated code disclosure.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
