### PR TITLE
Allow for parents in filestorage root_dir creation

### DIFF
--- a/src/gufe/storage/externalresource/filestorage.py
+++ b/src/gufe/storage/externalresource/filestorage.py
@@ -20,7 +20,7 @@ class FileStorage(ExternalStorage):
             If False, requires that `root_dir` not exist, by default False
         """
         self.root_dir = pathlib.Path(root_dir).resolve()
-        self.root_dir.mkdir(exist_ok=exist_ok)
+        self.root_dir.mkdir(parents=True, exist_ok=exist_ok)
 
     def _exists(self, location):
         return self._as_path(location).exists()


### PR DESCRIPTION
I was getting odd reports in a separate PR from claude inspection.
Looking into it, I think it makes sense to have the parents?

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
If yes, please provide details here: no AI generated code, but bug was identified originally from a claude review.

## Checklist
* [ ] Added a ``news`` entry
* [ ] Filled in the AI-generated code disclosure.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
