### PR TITLE
Update the default `samll_molecule_forcefield` setting

### DIFF
--- a/news/small_molecule_forcefield_update.rst
+++ b/news/small_molecule_forcefield_update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The default setting of `OpenMMSystemGeneratorFFSettings.small_molecule_forcefield` has been updated to `openff-2.1.0.offxml`. This setting now supports the full file name of an installed OpenFF small molecule force field, including the file extension.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/gufe/settings/models.py
+++ b/src/gufe/settings/models.py
@@ -166,7 +166,9 @@ class OpenMMSystemGeneratorFFSettings(BaseForceFieldSettings):
     ]
     """List of force field paths for all components except :class:`SmallMoleculeComponent` """
 
-    small_molecule_forcefield: str = "openff-2.2.1.offxml"  # other default ideas 'openff-2.0.0', 'gaff-2.11', 'espaloma-0.2.0'
+    small_molecule_forcefield: str = (
+        "openff-2.2.1.offxml"  # other default ideas 'openff-2.0.0', 'gaff-2.11', 'espaloma-0.2.0'
+    )
     """Name of the force field to be used for :class:`SmallMoleculeComponent` """
 
     nonbonded_method: str = "PME"

--- a/src/gufe/settings/models.py
+++ b/src/gufe/settings/models.py
@@ -166,7 +166,7 @@ class OpenMMSystemGeneratorFFSettings(BaseForceFieldSettings):
     ]
     """List of force field paths for all components except :class:`SmallMoleculeComponent` """
 
-    small_molecule_forcefield: str = "openff-2.2.1"  # other default ideas 'openff-2.0.0', 'gaff-2.11', 'espaloma-0.2.0'
+    small_molecule_forcefield: str = "openff-2.2.1.offxml"  # other default ideas 'openff-2.0.0', 'gaff-2.11', 'espaloma-0.2.0'
     """Name of the force field to be used for :class:`SmallMoleculeComponent` """
 
     nonbonded_method: str = "PME"

--- a/src/gufe/tests/test_models.py
+++ b/src/gufe/tests/test_models.py
@@ -103,7 +103,7 @@ def settings_validation_schema():
                 "type": "array",
             },
             "small_molecule_forcefield": {
-                "default": "openff-2.2.1",
+                "default": "openff-2.2.1.offxml",
                 "title": "Small Molecule Forcefield",
                 "type": "string",
             },
@@ -153,7 +153,7 @@ def expected_model_dump():
                 "amber/phosaa10.xml",
                 "amber/lipid17_merged.xml",
             ],
-            "small_molecule_forcefield": "openff-2.2.1",
+            "small_molecule_forcefield": "openff-2.2.1.offxml",
             "nonbonded_method": "PME",
             "nonbonded_cutoff": {"val": 1.1, "unit": "nanometer"},
         },

--- a/src/gufe/tests/test_serialization_json.py
+++ b/src/gufe/tests/test_serialization_json.py
@@ -289,7 +289,7 @@ class TestSettingsCodec(CustomJSONCodingTest):
                         "amber/phosaa10.xml",
                         "amber/lipid17_merged.xml",
                     ],
-                    "small_molecule_forcefield": "openff-2.2.1",
+                    "small_molecule_forcefield": "openff-2.2.1.offxml",
                     "nonbonded_method": "PME",
                     "nonbonded_cutoff": {
                         ":is_custom:": True,

--- a/src/gufe/tests/test_transformation.py
+++ b/src/gufe/tests/test_transformation.py
@@ -36,7 +36,7 @@ def complex_equilibrium(solvated_complex):
 
 class TestTransformation(GufeTokenizableTestsMixin):
     cls = Transformation
-    repr = "Transformation(stateA=ChemicalSystem(name=, components={'ligand': SmallMoleculeComponent(name=toluene), 'solvent': SolventComponent(name=O, K+, Cl-)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-e74b8a34526e7a7a5541d63e9ef511d5>, name=None, metadata={'sample_metadata_key': 'sample_metadata_value'})"
+    repr = "Transformation(stateA=ChemicalSystem(name=, components={'ligand': SmallMoleculeComponent(name=toluene), 'solvent': SolventComponent(name=O, K+, Cl-)}), stateB=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-24ff2c0ebbcc1af319043982f0b97f90>, name=None, metadata={'sample_metadata_key': 'sample_metadata_value'})"
 
     @pytest.fixture
     def instance(self, absolute_transformation):
@@ -210,7 +210,7 @@ class TestTransformation(GufeTokenizableTestsMixin):
 
 class TestNonTransformation(GufeTokenizableTestsMixin):
     cls = NonTransformation
-    repr = "NonTransformation(system=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-e74b8a34526e7a7a5541d63e9ef511d5>, name=None, metadata={})"
+    repr = "NonTransformation(system=ChemicalSystem(name=, components={'protein': ProteinComponent(name=), 'solvent': SolventComponent(name=O, K+, Cl-), 'ligand': SmallMoleculeComponent(name=toluene)}), protocol=<DummyProtocol-24ff2c0ebbcc1af319043982f0b97f90>, name=None, metadata={})"
 
     @pytest.fixture
     def instance(self, complex_equilibrium):


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Openmmforcefields now support the full file name for installed SMIRNOFF-style force fields, this Pr updates the default to use that convention which we should encourage going forward. 

Related to https://github.com/OpenFreeEnergy/openfe/pull/2152

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci atomically format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
If yes, please provide details here: No.

## Checklist
* [x] Added a ``news`` entry
* [x] Filled in the AI-generated code disclosure.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
